### PR TITLE
fix(nav): improve desktop profile link visibility

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -159,22 +159,22 @@
 
                 <div class="flex items-center space-x-3 md:space-x-4">
                     {% if user.is_some() %}
-                    <!-- User menu - responsive sizing -->
-                    <div class="flex items-center space-x-2 md:space-x-4">
-                        <a href="/discover" class="md:hidden text-gray-700 hover:text-primary-500 font-medium">
-                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-                            </svg>
-                        </a>
-                        <a href="/profile" class="hidden md:inline text-gray-700 hover:text-primary-500 font-medium">
-                            Profile
-                        </a>
-                        <form method="POST" action="/logout" class="inline">
-                            <button type="submit" class="text-sm md:text-base text-gray-700 hover:text-primary-500 font-medium">
-                                Logout
-                            </button>
-                        </form>
-                    </div>
+                    <!-- Mobile-only Discover icon -->
+                    <a href="/discover" class="md:hidden text-gray-700 hover:text-primary-500 font-medium">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                    </a>
+                    <!-- Desktop Profile link -->
+                    <a href="/profile" class="text-gray-700 hover:text-primary-500 font-medium max-md:hidden">
+                        Profile
+                    </a>
+                    <!-- Logout button -->
+                    <form method="POST" action="/logout" class="inline">
+                        <button type="submit" class="text-sm md:text-base text-gray-700 hover:text-primary-500 font-medium">
+                            Logout
+                        </button>
+                    </form>
                     {% else %}
                     <!-- Auth links - responsive sizing -->
                     <a href="/login" class="text-sm md:text-base text-gray-700 hover:text-primary-500 font-medium">


### PR DESCRIPTION
## Summary

Fix Profile link visibility on desktop navigation by restructuring the layout and using proper Tailwind v4.1+ responsive classes.

## Problem

The Profile link was not visible on desktop screens beside the Logout button due to:
1. Nested `<div>` wrapper causing layout issues
2. Incorrect responsive class combination (`hidden md:inline` instead of proper Tailwind v4 syntax)

## Solution

- ✅ Remove nested div wrapper - flatten nav structure for better flex layout
- ✅ Change Profile link to use `max-md:hidden` (Tailwind v4.1+ syntax)
- ✅ Profile link now properly visible on desktop (≥768px)
- ✅ Add clear comments for each navigation element

## Layout Behavior

**Mobile (<768px):**
- Discover icon (search) visible
- Profile link hidden (accessible via bottom nav tabs)
- Logout button visible

**Desktop (≥768px):**
- Discover icon hidden (available in main nav menu)
- **Profile link visible** ← Fixed!
- Logout button visible

## Technical Details

Uses Tailwind CSS v4.1.11 with proper responsive utilities:
- `max-md:hidden` = hidden on screens below 768px (mobile)
- Visible by default on 768px+ (tablet/desktop)

## Testing

Verified on:
- ✅ Mobile viewport (<768px): Profile hidden, accessible via bottom nav
- ✅ Desktop viewport (≥768px): Profile visible next to Logout

## Files Changed

- `templates/base.html`: Navigation structure and responsive classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)