### PR TITLE
feat(cli): add set-tier command for user subscription management

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,11 @@ async fn set_tier_command(
         .parse()
         .map_err(|e: String| anyhow::anyhow!("Invalid tier: {}", e))?;
 
-    tracing::info!("Parsed tier: {} ({})", subscription_tier, subscription_tier.as_str());
+    tracing::info!(
+        "Parsed tier: {} ({})",
+        subscription_tier,
+        subscription_tier.as_str()
+    );
 
     // Set up database connection pool
     let db_pool = SqlitePoolOptions::new()
@@ -547,7 +551,10 @@ async fn set_tier_command(
             email,
             subscription_tier
         );
-        println!("⚠️  User {} is already on {} tier", email, subscription_tier);
+        println!(
+            "⚠️  User {} is already on {} tier",
+            email, subscription_tier
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Adds a new CLI command `set-tier` that allows administrators to manually upgrade or downgrade user subscription tiers via email address input.

## Changes

- Added `SetTier` subcommand to the CLI with `--email` and `--tier` arguments
- Implemented `set_tier_command` function that:
  - Validates tier input (must be "free" or "premium")
  - Looks up user by email address
  - Checks if tier change is necessary
  - Executes `UpgradeSubscriptionCommand` via evento
  - Syncs read model via projections
  - Provides clear console feedback

## Usage

```bash
# Upgrade a user to premium tier
cargo run -- set-tier --email user@example.com --tier premium

# Downgrade a user to free tier
cargo run -- set-tier --email user@example.com --tier free
```

## Test Plan

- [x] Verify command compiles successfully
- [ ] Test upgrading free user to premium
- [ ] Test downgrading premium user to free
- [ ] Test error handling for invalid tier names
- [ ] Test error handling for non-existent user email
- [ ] Test no-op when tier is already set
- [ ] Verify evento events are persisted correctly
- [ ] Verify read model is updated via projections

🤖 Generated with [Claude Code](https://claude.com/claude-code)