### PR TITLE
test: fix 6 ignored tests across recipe and user modules

### DIFF
--- a/crates/recipe/tests/recipe_tests.rs
+++ b/crates/recipe/tests/recipe_tests.rs
@@ -2272,15 +2272,17 @@ async fn test_copy_recipe_prevents_duplicates() {
 
     // Verify the copied recipe was created with attribution metadata in database
     let copied_recipe_id = result_1.unwrap();
-    let attribution_check: Option<String> = sqlx::query_scalar(
-        "SELECT original_recipe_id FROM recipes WHERE id = ?1"
-    )
-    .bind(&copied_recipe_id)
-    .fetch_optional(&pool)
-    .await
-    .unwrap();
-    assert_eq!(attribution_check, Some(original_recipe_id.clone()),
-        "Attribution metadata (original_recipe_id) should be set in read model after projection");
+    let attribution_check: Option<String> =
+        sqlx::query_scalar("SELECT original_recipe_id FROM recipes WHERE id = ?1")
+            .bind(&copied_recipe_id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        attribution_check,
+        Some(original_recipe_id.clone()),
+        "Attribution metadata (original_recipe_id) should be set in read model after projection"
+    );
 
     // AC-10: Second copy should fail with AlreadyCopied error
     let copy_command_2 = CopyRecipeCommand {
@@ -2289,7 +2291,8 @@ async fn test_copy_recipe_prevents_duplicates() {
     let result_2 = copy_recipe(copy_command_2, &copier_id, &executor, &pool).await;
     assert!(
         matches!(result_2, Err(RecipeError::AlreadyCopied)),
-        "Second copy should fail with AlreadyCopied error, got: {:?}", result_2
+        "Second copy should fail with AlreadyCopied error, got: {:?}",
+        result_2
     );
 }
 

--- a/crates/recipe/tests/recipe_tests.rs
+++ b/crates/recipe/tests/recipe_tests.rs
@@ -2194,7 +2194,6 @@ async fn test_copy_recipe_success() {
 /// Test: copy_recipe prevents duplicate copies
 /// AC-10
 #[tokio::test]
-#[ignore = "Projection timing issues - needs investigation"]
 async fn test_copy_recipe_prevents_duplicates() {
     let pool = setup_test_db().await;
     let executor = setup_evento_executor(pool.clone()).await;
@@ -2261,15 +2260,27 @@ async fn test_copy_recipe_prevents_duplicates() {
     let result_1 = copy_recipe(copy_command_1, &copier_id, &executor, &pool).await;
     assert!(result_1.is_ok(), "First copy should succeed");
 
-    // Run projection (may need multiple passes for all events)
-    recipe_projection(pool.clone())
-        .unsafe_oneshot(&executor)
-        .await
-        .unwrap();
-    recipe_projection(pool.clone())
-        .unsafe_oneshot(&executor)
-        .await
-        .unwrap();
+    // Run projection multiple times to ensure ALL events are processed
+    // copy_recipe emits TWO separate events: RecipeCreated (new recipe) and RecipeCopied (attribution)
+    // unsafe_oneshot processes events in batches, so we need multiple calls
+    for _ in 0..3 {
+        recipe_projection(pool.clone())
+            .unsafe_oneshot(&executor)
+            .await
+            .unwrap();
+    }
+
+    // Verify the copied recipe was created with attribution metadata in database
+    let copied_recipe_id = result_1.unwrap();
+    let attribution_check: Option<String> = sqlx::query_scalar(
+        "SELECT original_recipe_id FROM recipes WHERE id = ?1"
+    )
+    .bind(&copied_recipe_id)
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert_eq!(attribution_check, Some(original_recipe_id.clone()),
+        "Attribution metadata (original_recipe_id) should be set in read model after projection");
 
     // AC-10: Second copy should fail with AlreadyCopied error
     let copy_command_2 = CopyRecipeCommand {
@@ -2278,14 +2289,13 @@ async fn test_copy_recipe_prevents_duplicates() {
     let result_2 = copy_recipe(copy_command_2, &copier_id, &executor, &pool).await;
     assert!(
         matches!(result_2, Err(RecipeError::AlreadyCopied)),
-        "Second copy should fail with AlreadyCopied error"
+        "Second copy should fail with AlreadyCopied error, got: {:?}", result_2
     );
 }
 
 /// Test: copy_recipe enforces freemium limit
 /// AC-5, AC-11
 #[tokio::test]
-#[ignore = "Projection timing issues - needs investigation"]
 async fn test_copy_recipe_enforces_freemium_limit() {
     let pool = setup_test_db().await;
     let executor = setup_evento_executor(pool.clone()).await;
@@ -2372,12 +2382,12 @@ async fn test_copy_recipe_enforces_freemium_limit() {
         .unwrap();
     }
 
-    // Run projection (may need multiple passes for all events)
+    // Run projection to sync all created recipes to read model (updates user's recipe_count)
     recipe_projection(pool.clone())
         .unsafe_oneshot(&executor)
         .await
         .unwrap();
-    recipe_projection(pool.clone())
+    user::user_projection(pool.clone())
         .unsafe_oneshot(&executor)
         .await
         .unwrap();
@@ -2477,7 +2487,6 @@ async fn test_copy_recipe_validates_recipe_exists() {
 /// Test: copied recipe modifications don't affect original
 /// AC-7
 #[tokio::test]
-#[ignore = "Projection timing issues - needs investigation"]
 async fn test_copy_recipe_modifications_independent() {
     let pool = setup_test_db().await;
     let executor = setup_evento_executor(pool.clone()).await;
@@ -2545,11 +2554,7 @@ async fn test_copy_recipe_modifications_independent() {
         .await
         .unwrap();
 
-    // Run projection to update read model with copied recipe (may need multiple passes)
-    recipe_projection(pool.clone())
-        .unsafe_oneshot(&executor)
-        .await
-        .unwrap();
+    // Run projection to sync the copied recipe to read model
     recipe_projection(pool.clone())
         .unsafe_oneshot(&executor)
         .await

--- a/crates/user/src/types.rs
+++ b/crates/user/src/types.rs
@@ -13,7 +13,9 @@ use std::str::FromStr;
 /// preventing typos and invalid tier assignments.
 ///
 /// ## Usage
-/// ```ignore
+/// ```
+/// use user::types::SubscriptionTier;
+///
 /// let tier = SubscriptionTier::Free;
 /// assert_eq!(tier.as_str(), "free");
 ///

--- a/tests/recipe_integration_tests.rs
+++ b/tests/recipe_integration_tests.rs
@@ -218,7 +218,6 @@ async fn test_query_recipes_by_user() {
 
 // Note: Delete tests temporarily disabled as delete functionality is out of scope for Story 2.1 (Create Recipe only)
 #[tokio::test]
-#[ignore]
 async fn test_delete_recipe_integration() {
     let pool = setup_test_db().await;
     let executor = setup_evento_executor(pool.clone()).await;
@@ -265,7 +264,7 @@ async fn test_delete_recipe_integration() {
     // Delete recipe
     let delete_command = DeleteRecipeCommand {
         recipe_id: recipe_id.clone(),
-        user_id: "user1".to_string(),
+        user_id: user1_id.to_string(),
     };
     delete_recipe(delete_command, &executor, &pool)
         .await
@@ -282,12 +281,11 @@ async fn test_delete_recipe_integration() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_delete_recipe_permission_denied() {
     let pool = setup_test_db().await;
     let executor = setup_evento_executor(pool.clone()).await;
     let user1_id = create_test_user_for_tests(&pool, &executor, "user1@test.com", "free").await;
-    let _user2_id = create_test_user_for_tests(&pool, &executor, "user2@test.com", "free").await;
+    let user2_id = create_test_user_for_tests(&pool, &executor, "user2@test.com", "free").await;
 
     // Start projection
     // Process events synchronously for deterministic tests
@@ -326,7 +324,7 @@ async fn test_delete_recipe_permission_denied() {
     // User2 tries to delete user1's recipe
     let delete_command = DeleteRecipeCommand {
         recipe_id: recipe_id.clone(),
-        user_id: "user2".to_string(), // Different user!
+        user_id: user2_id.to_string(), // Different user!
     };
     let result = delete_recipe(delete_command, &executor, &pool).await;
 


### PR DESCRIPTION
## Summary
Fixes 6 ignored tests by addressing projection timing issues and using correct user IDs.

## Changes

### Recipe Integration Tests (`tests/recipe_integration_tests.rs`)
- ✅ **test_delete_recipe_integration**: Fixed hardcoded user ID (`"user1"` → `user1_id.to_string()`)
- ✅ **test_delete_recipe_permission_denied**: Fixed hardcoded user ID (`"user2"` → `user2_id.to_string()`)

### Recipe Copy Tests (`crates/recipe/tests/recipe_tests.rs`)
- ✅ **test_copy_recipe_prevents_duplicates**: Added projection loop (3 iterations) to process both `RecipeCreated` and `RecipeCopied` events
- ✅ **test_copy_recipe_enforces_freemium_limit**: Added `user_projection` call to update recipe count for freemium limit checks
- ✅ **test_copy_recipe_modifications_independent**: Simplified projection calls

### User Types Doc Test (`crates/user/src/types.rs`)
- ✅ **SubscriptionTier doc test**: Changed ````ignore` to proper doc test with `use` statement

## Root Cause
The main issue was that evento's `unsafe_oneshot` processes events synchronously but in batches. When `copy_recipe` emits multiple events (`RecipeCreated` then `RecipeCopied`), they require multiple projection passes to be fully synced to the read model.

## Test Results
All 6 tests now pass without `#[ignore]` attributes:
- `cargo test` shows **0 ignored tests**
- All test suites pass successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)