### PR TITLE
fix(user): register cross-domain recipe event handlers for favorite_count

### DIFF
--- a/crates/user/src/lib.rs
+++ b/crates/user/src/lib.rs
@@ -24,5 +24,8 @@ pub use events::{
 };
 pub use jwt::{generate_jwt, generate_reset_token, validate_jwt, Claims};
 pub use password::{hash_password, verify_password};
-pub use read_model::{query_user_by_email, query_user_for_login, user_projection, UserLoginData};
+pub use read_model::{
+    query_user_by_email, query_user_for_login, user_projection, user_recipe_projection,
+    UserLoginData,
+};
 pub use types::SubscriptionTier;

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,12 @@ async fn serve_command(
         .await?;
     tracing::info!("Evento subscription 'user-read-model' started");
 
+    // Cross-domain subscription: user domain listening to recipe events
+    user::user_recipe_projection::<recipe::aggregate::RecipeAggregate>(db_pool.clone())
+        .run(&evento_executor)
+        .await?;
+    tracing::info!("Evento subscription 'user-recipe-events' started");
+
     recipe_projection(db_pool.clone())
         .run(&evento_executor)
         .await?;


### PR DESCRIPTION
## Summary

Fixes issue where **favorite_count was always showing 0** in profile settings, even when users had favorited recipes.

## Problem

The favorite count on the profile page (templates/pages/profile.html:18) was always 0 because the `RecipeFavorited` event handlers in the user domain were never being invoked.

### Root Cause

The evento subscription architecture had a flaw:
- `user_projection()` subscription only listened to `UserAggregate` events
- `RecipeFavorited`, `RecipeCreated`, `RecipeDeleted`, `RecipeShared` events are emitted by `RecipeAggregate`
- Cross-domain event handlers were registered in `user_projection()` but never received events because the subscription was filtered to only `UserAggregate` events

## Solution

Created a **separate subscription for cross-domain events**:

1. **New function**: `user_recipe_projection<A>()`
   - Generic over aggregate type to avoid circular dependency
   - Listens specifically to `RecipeAggregate` events
   - Contains only cross-domain handlers

2. **Registration in main.rs**:
   ```rust
   user::user_recipe_projection::<recipe::aggregate::RecipeAggregate>(pool.clone())
       .run(&executor).await?;
   ```

3. **Separation of concerns**:
   - `user_projection()` → handles UserAggregate events only
   - `user_recipe_projection()` → handles RecipeAggregate events for user domain

## Changes

- **crates/user/src/read_model.rs**:
  - Added `user_recipe_projection()` function
  - Removed cross-domain handlers from `user_projection()`
  
- **crates/user/src/lib.rs**:
  - Export `user_recipe_projection` function

- **src/main.rs**:
  - Register `user_recipe_projection<RecipeAggregate>()` subscription

## Impact

Now when users favorite/unfavorite recipes:
- ✅ `favorite_count` increments/decrements correctly in users table
- ✅ Profile page displays accurate favorite count
- ✅ Dashboard shows correct favorite count
- ✅ `recipe_count` also updates correctly (same fix applies)

## Testing

- ✅ All workspace tests passing (`make test`)
- ✅ No circular dependencies
- ✅ Clean separation of domain event handling

## Technical Notes

This is a common pattern in event-sourced systems with multiple bounded contexts. The evento framework matches events by type name, but subscriptions must explicitly listen to the aggregates they care about. Cross-domain event handlers require separate subscriptions for each aggregate type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)