### PR TITLE
fix: resolve invalid ECDSA P-256 public key error in push notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,7 @@ dependencies = [
  "async-stripe",
  "axum",
  "axum-extra",
+ "base64 0.22.1",
  "bincode",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ mime_guess = { workspace = true }
 lettre = { workspace = true }
 urlencoding = { workspace = true }
 async-stripe = { workspace = true }
+base64 = { workspace = true }
 user = { path = "crates/user", version = "0.6.0" }
 recipe = { path = "crates/recipe", version = "0.6.0" }
 meal_planning = { path = "crates/meal_planning", version = "0.6.0" }

--- a/config/default.toml
+++ b/config/default.toml
@@ -81,19 +81,16 @@ price_id = ""  # REQUIRED: Add your price ID
 # Generate keys with: npx web-push generate-vapid-keys
 # Or use: openssl ecparam -genkey -name prime256v1 -out vapid_private.pem
 [vapid]
-# VAPID public key (base64url encoded)
+# VAPID public key (base64url encoded, uncompressed P-256)
 # This is included in the push subscription request from the browser
 # Override with: IMKITCHEN__VAPID__PUBLIC_KEY
-public_key = "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nqm50g"
+public_key = "BB8rIhib51reZc8Yy_MNyeWlTNpYKumwCoB5m1Sd4ggjvo_w3QtfO8XXrzxHPkoVkoVNvCdD50mbl75FYthMnN0"
 
-# VAPID private key (PEM format)
+# VAPID private key (base64url encoded raw key)
 # Keep this secret! Never commit to version control in production
 # Override with: IMKITCHEN__VAPID__PRIVATE_KEY
-private_key = """-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIBnY0u6XvJ8R3z6aKOvN3cTwLxMjKKdW8YVJqV9LKqAVoAoGCCqGSM49
-AwEHoUQDQgAEEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjS
-gSnfckjBJuBkr3qBUYIHBQFLXYp5Nqm50g==
------END EC PRIVATE KEY-----"""
+# Note: web-push crate expects PEM format, we'll need to convert this on load
+private_key = "gQbVG-hmJgxI1hVm3RkXGEbA_B0mC-Z7vCmy4l5EUrk"
 
 # VAPID subject (mailto: or https: URL)
 # Identifies your application to push services

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,8 +160,15 @@ impl VapidConfig {
             return Ok(self.private_key.clone());
         }
 
-        // Convert base64url to base64 standard
-        let base64_standard = self.private_key.replace('-', "+").replace('_', "/");
+        // Convert base64url to base64 standard and add padding
+        let mut base64_standard = self.private_key.replace('-', "+").replace('_', "/");
+
+        // Add padding if needed (base64 strings must be multiple of 4 chars)
+        match base64_standard.len() % 4 {
+            2 => base64_standard.push_str("=="),
+            3 => base64_standard.push('='),
+            _ => {} // 0 or 1 (1 would be invalid, but we'll let decode catch it)
+        }
 
         // Decode base64 to raw bytes
         let raw_key = STANDARD


### PR DESCRIPTION
## Summary

Fixes the `DOMException: Invalid raw ECDSA P-256 public key` error that occurred when users attempted to subscribe to push notifications.

## Root Cause

The error was caused by two issues:
1. **Mismatched VAPID key pair** - The public and private keys in the config were from different key pairs
2. **Missing format conversion** - The server wasn't converting the base64url-encoded private key to PEM format required by the `web-push` crate

## Changes

### 1. Updated VAPID Keys (`config/default.toml`)
- Generated a new matching VAPID key pair using `npx web-push generate-vapid-keys`
- Updated both public and private keys to be from the same pair
- Stored private key in base64url format for easier configuration

### 2. Added PEM Conversion (`src/config.rs`)
- Created `VapidConfig::private_key_as_pem()` method
- Converts base64url private keys to PEM format (required by web-push crate)
- Properly constructs DER-encoded EC private key for P-256 curve
- Supports both legacy PEM format and new base64url format

### 3. Updated Server Initialization (`src/main.rs`)
- Modified VAPID config initialization to convert private key to PEM
- Added error handling with informative logging
- Gracefully disables push notifications if conversion fails

### 4. Added Dependency (`Cargo.toml`)
- Added `base64` crate to main binary dependencies for key conversion

## Client-Side

No changes needed - the existing `urlBase64ToUint8Array()` function correctly converts base64url VAPID keys to Uint8Array format for the browser Push API.

## Testing

- ✅ Build completes successfully with `cargo build`
- ✅ VAPID private key converts correctly to PEM format
- ✅ Public key remains in base64url format for browser compatibility

## Test Plan

1. Start the application with the new VAPID keys
2. Navigate to notifications settings page
3. Click "Enable Push Notifications"
4. Verify subscription is created without errors
5. Verify subscription is saved to database
6. Send a test push notification to confirm end-to-end functionality

## Technical Details

**VAPID Key Formats:**
- **Public Key**: Base64url-encoded (browser Push API requirement)
- **Private Key**: PEM-encoded (web-push crate requirement)

The fix ensures both formats are properly handled without requiring manual conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)