### PR TITLE
fix: display meal plan generation errors inline to users

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -189,6 +189,19 @@ impl IntoResponse for AppError {
                     None,
                 )
             }
+            // Issue #130: Handle InsufficientRecipes from meal_planning domain separately
+            AppError::MealPlanningError(meal_planning::MealPlanningError::InsufficientRecipes { minimum, current }) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Not Enough Recipes".to_string(),
+                format!(
+                    "You need at least {} favorite recipes to generate a meal plan. You currently have {}. Add {} more recipe{} to get started!",
+                    minimum,
+                    current,
+                    minimum - current,
+                    if minimum - current > 1 { "s" } else { "" }
+                ),
+                Some("insufficient_recipes".to_string()),
+            ),
             AppError::MealPlanningError(e) => {
                 tracing::error!("Meal planning error: {:?}", e);
                 (

--- a/templates/pages/dashboard.html
+++ b/templates/pages/dashboard.html
@@ -230,6 +230,8 @@ button.ts-active::after {
                             ts-req="/plan/generate"
                             ts-req-method="POST"
                             ts-trigger="click"
+                            ts-target="body"
+                            ts-swap="inner"
                             class="px-6 py-3 bg-primary-700 text-white rounded-lg hover:bg-primary-800 transition-colors font-semibold border-2 border-white/20">
                                     Regenerate Plan
                                 </button>
@@ -282,6 +284,8 @@ button.ts-active::after {
                             ts-req="/plan/generate"
                             ts-req-method="POST"
                             ts-trigger="click"
+                            ts-target="body"
+                            ts-swap="inner"
                             class="px-8 py-4 bg-white text-primary-600 rounded-lg hover:bg-primary-50 transition-colors font-bold text-lg shadow-md">
                                 Generate Meal Plan
                             </button>

--- a/templates/pages/meal-calendar.html
+++ b/templates/pages/meal-calendar.html
@@ -71,7 +71,8 @@ button.ts-active::after {
                     ts-req="/plan/generate"
                     ts-req-method="POST"
                     ts-trigger="click"
-                    ts-target="#main-content"
+                    ts-target="body"
+                    ts-swap="inner"
                     class="px-8 py-4 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors font-bold text-lg">
                     Generate Meal Plan
                 </button>
@@ -328,9 +329,23 @@ button.ts-active::after {
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
                 </svg>
                 <h2 class="text-2xl font-bold text-gray-900 mb-2">No Meal Plan Yet</h2>
+
+                <!-- Issue #130: Display inline error message -->
+                {% match error_message %}
+                {% when Some with (msg) %}
+                <div class="mb-6 bg-amber-50 border-l-4 border-amber-400 p-4 rounded-r-lg">
+                    <div class="flex items-start">
+                        <svg class="h-6 w-6 text-amber-600 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        <p class="text-amber-800 font-medium text-left">{{ msg }}</p>
+                    </div>
+                </div>
+                {% when None %}
                 <p class="text-gray-600 mb-6">
                     Generate your first weekly meal plan based on your favorite recipes. You'll need at least 7 favorite recipes to get started.
                 </p>
+                {% endmatch %}
                 <div class="space-y-3 text-left bg-blue-50 p-4 rounded-lg mb-6">
                     <p class="font-semibold text-blue-900">To get started:</p>
                     <ol class="list-decimal list-inside space-y-2 text-blue-800">


### PR DESCRIPTION
## Summary
Fixes meal plan generation errors not being properly displayed to users (issue #130).

## Problem
When meal plan generation failed due to business logic errors (e.g., InsufficientRecipes), the error was logged but not communicated to the UI. Users saw an abort/crash without explanation.

## Solution
- **Inline error display**: Returns 200 OK with meal calendar page containing error message
- **User-friendly messaging**: Clear, actionable error messages (e.g., "You need at least 7 favorite recipes...")
- **Informational styling**: Amber/yellow design (not alarming red) with helpful icon
- **TwinSpark compatible**: All generation buttons target `body` for full page replacement

## Changes
### Backend (`src/error.rs`)
- Added specific handler for `MealPlanningError::InsufficientRecipes`
- Provides user-friendly message with recipe count details

### Routes (`src/routes/meal_plan.rs`)
- Changed return type to `Html<String>` for inline error handling
- Added `error_message: Option<String>` to `MealCalendarTemplate`
- Route-level and algorithm-level errors return meal calendar with error message

### Templates
- **`meal-calendar.html`**: Display inline error in amber box with icon
- **`dashboard.html`**: Updated TwinSpark targets to `body` (2 buttons)
- **`meal-calendar.html`**: Updated TwinSpark target to `body`

## Testing
- ✅ All existing tests pass
- ✅ Build successful
- ✅ Error messages display correctly in UI

## Example User Flow
1. User clicks "Generate Meal Plan" with insufficient recipes
2. Server returns 200 OK with error message inline
3. User sees: "You need at least 7 favorite recipes to generate a meal plan. You currently have 3. Add 4 more recipes to get started!"
4. Actionable buttons: "Create Recipe" and "Browse Community"

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)