### PR TITLE
feat: add week context to shopping list navigation from meal plan

### DIFF
--- a/templates/pages/meal-calendar.html
+++ b/templates/pages/meal-calendar.html
@@ -50,7 +50,7 @@ button.ts-active::after {
 
             <div class="flex gap-3">
                 {% if has_meal_plan %}
-                <a href="/shopping" class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium flex items-center">
+                <a href="/shopping?week={{ start_date }}" class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium flex items-center">
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"></path>
                     </svg>


### PR DESCRIPTION
## Summary
Navigate to week-specific shopping list when clicking "Shopping List" button on meal plan page.

## Changes
- Updated shopping list link in meal calendar template to include `week` query parameter
- Link now navigates to `/shopping?week={{ start_date }}` instead of `/shopping`
- Uses existing `start_date` variable from template context (Monday of the meal plan week)

## Impact
Users will now see the shopping list for the displayed meal plan week rather than the default current week when clicking the "Shopping List" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)