### PR TITLE
fix(shopping): fix week selector and default to next week

### DIFF
--- a/src/routes/meal_planning_api.rs
+++ b/src/routes/meal_planning_api.rs
@@ -448,7 +448,7 @@ async fn load_favorite_recipes(
 /// Load user's meal planning preferences from users table (Story 8.1 AC-5)
 ///
 /// Queries users table for dietary restrictions, skill level, and time constraints.
-async fn load_user_preferences(
+pub async fn load_user_preferences(
     user_id: &str,
     db_pool: &SqlitePool,
 ) -> Result<UserPreferences, ApiError> {

--- a/templates/pages/shopping-list.html
+++ b/templates/pages/shopping-list.html
@@ -92,9 +92,10 @@ details[open] summary .chevron {
                 name="week"
                 class="w-full md:max-w-xs px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 style="min-height: 44px;"
-                ts-req="/shopping?week={value}"
+                ts-req="/shopping"
+                ts-req-selector="#shopping-list-content"
                 ts-target="#shopping-list-content"
-                ts-swap="innerHTML"
+                ts-swap="inner"
                 ts-trigger="change"
                 ts-req-history="replace"
             >


### PR DESCRIPTION
## Summary
- Fix week selector duplicate parameter error using ts-req-selector
- Change default week to next week since current week is locked for shopping
- Fix failing tests in meal_planning crate
- Fix compiler warnings and refactor polling endpoint

## Changes
- Use `ts-req-selector="#shopping-list-content"` to extract content from full page response
- Default shopping list to next week (current + 7 days) instead of current week
- Update tests to match current behavior where preferences don't filter favorites
- Add validation requiring minimum 7 recipes of each type
- Remove unused imports and simplify polling endpoint

## Test plan
- [x] Shopping list week selector works without 400 error
- [x] Shopping list defaults to next week
- [x] All 476 tests passing with `make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)