### PR TITLE
chore(deps): bump evento to 2.0.0-alpha.19 (projection define-once API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1692,8 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "evento"
-version = "2.0.0-alpha.18"
-source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
+version = "2.0.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf84a32a9585db0e288f73b743d8e4018d7ac2096225fbb458741402928e2c5"
 dependencies = [
  "evento-core",
  "evento-sql",
@@ -1703,8 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "evento-core"
-version = "2.0.0-alpha.18"
-source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
+version = "2.0.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340cff20a50abe255301ce84caebde754a6109c4027038f3bc3645333abadee7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1723,8 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "evento-macro"
-version = "2.0.0-alpha.18"
-source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
+version = "2.0.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0169fe3d219a982d1dd8b3a5c1fb460c867a64faaf31d6477a9435a68fe7926"
 dependencies = [
  "convert_case 0.11.0",
  "quote",
@@ -1733,8 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql"
-version = "2.0.0-alpha.18"
-source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
+version = "2.0.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded88a1366a0729a0be1023ac1be52df596c12be37192bb33e1ad49342ca0933"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1748,8 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql-migrator"
-version = "2.0.0-alpha.18"
-source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
+version = "2.0.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b25bec9ecffed94d79338ca02636c77637db3f693ce8667c979fa5df02a796"
 dependencies = [
  "async-trait",
  "evento-sql",
@@ -2898,7 +2903,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5235,7 +5240,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6095,7 +6100,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7014,7 +7019,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1693,8 +1693,7 @@ dependencies = [
 [[package]]
 name = "evento"
 version = "2.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bdc476aba45210e993d120a6109d465acd668ec6e73abf83d3a2c7204391e7"
+source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
 dependencies = [
  "evento-core",
  "evento-sql",
@@ -1705,8 +1704,7 @@ dependencies = [
 [[package]]
 name = "evento-core"
 version = "2.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8dd700e5faced3c303e887a5f1ecaaebbcc2fec32baa31ab6f65e654077b3a"
+source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1726,8 +1724,7 @@ dependencies = [
 [[package]]
 name = "evento-macro"
 version = "2.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058b67b925b8d70e8f95cb427cb38b52487ffb33dccd805ceec608342af68f0e"
+source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
 dependencies = [
  "convert_case 0.11.0",
  "quote",
@@ -1737,8 +1734,7 @@ dependencies = [
 [[package]]
 name = "evento-sql"
 version = "2.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eec2096c45afe17ad105c6a707f6fd0d207a91f6d85084b48a103f5d672916c"
+source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1753,8 +1749,7 @@ dependencies = [
 [[package]]
 name = "evento-sql-migrator"
 version = "2.0.0-alpha.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb11cf005ca94747b60df639766f0db545f152be97c0636c212ad42e53ca07f"
+source = "git+https://github.com/timayz/evento.git?branch=feat%2Fprojection%2Fall-in-subscription#a9eb139ded7f779c263932dc9c2754205c506ed2"
 dependencies = [
  "async-trait",
  "evento-sql",
@@ -2903,7 +2898,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5240,7 +5235,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6100,7 +6095,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7019,7 +7014,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ askama = "0.16"
 world-tax = "0.5"
 sqlx = { version = "0.9", default-features = false, features = ["migrate", "json", "derive", "runtime-tokio", "sqlite"] }
 sqlx_migrator = { version = "0.19", features = ["sqlite"] }
-evento = { git = "https://github.com/timayz/evento.git", branch = "feat/projection/all-in-subscription", features = ["sqlite", "rw"] }
+evento = { version = "2.0.0-alpha.19", features = ["sqlite", "rw"] }
 argon2 = { version = "0.5", features = ["std"] }
 jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 lettre = { version = "0.11", features = ["rustls-tls", "builder"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ askama = "0.16"
 world-tax = "0.5"
 sqlx = { version = "0.9", default-features = false, features = ["migrate", "json", "derive", "runtime-tokio", "sqlite"] }
 sqlx_migrator = { version = "0.19", features = ["sqlite"] }
-evento = { version = "2.0.0-alpha.18", features = ["sqlite", "rw"] }
+evento = { git = "https://github.com/timayz/evento.git", branch = "feat/projection/all-in-subscription", features = ["sqlite", "rw"] }
 argon2 = { version = "0.5", features = ["std"] }
 jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 lettre = { version = "0.11", features = ["rustls-tls", "builder"] }

--- a/crates/billing/src/invoice_user.rs
+++ b/crates/billing/src/invoice_user.rs
@@ -38,11 +38,9 @@ pub(crate) async fn load<E: Executor>(
     write_db: &SqlitePool,
     id: impl Into<String>,
 ) -> Result<Option<InvoiceUserView>, anyhow::Error> {
-    let id = id.into();
-
-    create_projection(&id)
-        .aggregator::<invoice::Invoice>(id)
+    create_projection()
         .data((read_db.clone(), write_db.clone()))
+        .load(id)
         .execute(executor)
         .await
 }
@@ -159,8 +157,8 @@ impl<E: Executor> Module<E> {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, InvoiceUserView> {
-    Projection::new::<invoice::Invoice>(id).handler(handle_created())
+pub fn create_projection<E: Executor>() -> Projection<E, InvoiceUserView> {
+    Projection::new::<invoice::Invoice>().handler(handle_created())
 }
 
 impl<E: Executor> Snapshot<E> for InvoiceUserView {

--- a/crates/billing/src/subscription/mod.rs
+++ b/crates/billing/src/subscription/mod.rs
@@ -26,7 +26,8 @@ impl<E: Executor> Deref for Module<E> {
 impl<E: Executor> Module<E> {
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Subscription> {
         let id = id.into();
-        create_projection::<E>(&id)
+        create_projection::<E>()
+            .load(&id)
             .execute(&self.executor)
             .await
             .map(|r| {
@@ -63,8 +64,8 @@ pub struct Subscription {
     pub is_active: bool,
 }
 
-fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Subscription> {
-    Projection::new::<subscription::Subscription>(id)
+fn create_projection<E: Executor>() -> Projection<E, Subscription> {
+    Projection::new::<subscription::Subscription>()
         .handler(handle_life_premium_toggled())
         .handler(handle_stripe_customer_created())
         .handler(handle_stripe_payment_intent_created())

--- a/crates/core/src/contact/query/admin.rs
+++ b/crates/core/src/contact/query/admin.rs
@@ -126,8 +126,9 @@ pub(crate) async fn load<E: Executor>(
     write_db: &SqlitePool,
     id: impl Into<String>,
 ) -> Result<Option<AdminView>, anyhow::Error> {
-    create_projection(id)
+    create_projection()
         .data((read_db.clone(), write_db.clone()))
+        .load(id)
         .execute(executor)
         .await
 }
@@ -161,8 +162,8 @@ pub(crate) async fn find(
     )
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, AdminView> {
-    Projection::new::<Contact>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, AdminView> {
+    Projection::new::<Contact>()
         .handler(handle_form_submmited())
         .handler(handle_reopened())
         .handler(handle_marked_read_and_reply())

--- a/crates/core/src/contact/query/mod.rs
+++ b/crates/core/src/contact/query/mod.rs
@@ -1,26 +1,2 @@
-use evento::{
-    Executor,
-    metadata::RawEvent,
-    subscription::{Context, SubscriptionBuilder},
-};
-use imkitchen_types::contact::FormSubmitted;
-use sqlx::SqlitePool;
-
 pub mod admin;
 pub mod global_stat;
-
-pub fn query_subscription<E: Executor>() -> SubscriptionBuilder<E> {
-    SubscriptionBuilder::new("contact-query")
-        .handler(handle_contact_all())
-        .safety_check()
-}
-
-#[evento::subscription_all]
-async fn handle_contact_all<E: Executor>(
-    context: &Context<'_, E>,
-    event: RawEvent<FormSubmitted>,
-) -> anyhow::Result<()> {
-    let (r, w) = context.extract::<(SqlitePool, SqlitePool)>();
-    admin::load(context.executor, &r, &w, &event.aggregator_id).await?;
-    Ok(())
-}

--- a/crates/core/src/contact/root/mod.rs
+++ b/crates/core/src/contact/root/mod.rs
@@ -29,7 +29,7 @@ impl<E: Executor> Module<E> {
     }
 
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<Contact>> {
-        create_projection(id).execute(&self.executor).await
+        create_projection().load(id).execute(&self.executor).await
     }
 }
 
@@ -45,8 +45,8 @@ impl ProjectionAggregator for Contact {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Contact> {
-    Projection::new::<contact::Contact>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, Contact> {
+    Projection::new::<contact::Contact>()
         .handler(handle_form_submitted())
         .handler(handle_reopened())
         .handler(handle_resolved())

--- a/crates/core/src/mealplan/root/mod.rs
+++ b/crates/core/src/mealplan/root/mod.rs
@@ -39,7 +39,7 @@ impl<E: Executor> Module<E> {
     }
 
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<MealPlan>> {
-        create_projection(id).execute(&self.executor).await
+        create_projection().load(id).execute(&self.executor).await
     }
 }
 
@@ -55,8 +55,8 @@ impl ProjectionAggregator for MealPlan {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, MealPlan> {
-    Projection::new::<mealplan::MealPlan>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, MealPlan> {
+    Projection::new::<mealplan::MealPlan>()
         .handler(handle_generated())
         .skip::<SlotRecipeStatusChanged>()
         .safety_check()

--- a/crates/core/src/recipe/favorite/mod.rs
+++ b/crates/core/src/recipe/favorite/mod.rs
@@ -26,7 +26,8 @@ impl<E: Executor> Module<E> {
         let id = id.into();
         let user_id = user_id.into();
 
-        create_projection::<E>(&id, &user_id)
+        create_projection::<E>()
+            .load_ids(vec![id.clone(), user_id.clone()])
             .execute(&self.executor)
             .await
             .map(|r| {
@@ -45,11 +46,8 @@ pub struct Favorite {
     pub saved: bool,
 }
 
-pub fn create_projection<E: Executor>(
-    id: impl Into<String>,
-    user_id: impl Into<String>,
-) -> Projection<E, Favorite> {
-    Projection::ids::<favorite::Favorite>(vec![id.into(), user_id.into()])
+pub fn create_projection<E: Executor>() -> Projection<E, Favorite> {
+    Projection::new::<favorite::Favorite>()
         .handler(handle_saved())
         .handler(handle_unsaved())
         .safety_check()

--- a/crates/core/src/recipe/query/mod.rs
+++ b/crates/core/src/recipe/query/mod.rs
@@ -3,46 +3,22 @@ pub mod user;
 pub mod user_fts;
 pub mod user_stat;
 
-use evento::metadata::Event;
 use evento::{
-    AggregatorEvent, Executor,
-    metadata::RawEvent,
+    Executor,
+    metadata::Event,
     subscription::{Context, SubscriptionBuilder},
 };
 use imkitchen_db::recipe_user::RecipeUser;
-use imkitchen_types::recipe;
 use imkitchen_types::recipe_share::{AllMadePrivate, AllSharedToCommunity};
 use sea_query::{Expr, ExprTrait, SqliteQueryBuilder};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::SqlitePool;
 
 pub fn subscription<E: Executor>() -> SubscriptionBuilder<E> {
-    SubscriptionBuilder::new("recipe-query")
-        .handler(handle_recipe_all())
+    SubscriptionBuilder::new("recipe-query-share")
         .handler(handle_all_shared_to_community())
         .handler(handle_all_made_private())
         .safety_check()
-}
-
-#[evento::subscription_all]
-async fn handle_recipe_all<E: Executor>(
-    context: &Context<'_, E>,
-    event: RawEvent<recipe::Created>,
-) -> anyhow::Result<()> {
-    let (r, w) = context.extract::<(SqlitePool, SqlitePool)>();
-    if event.name != recipe::Deleted::event_name() {
-        user::load(context.executor, &r, &w, &event.aggregator_id).await?;
-        return Ok(());
-    }
-    let (sql, values) = sea_query::Query::delete()
-        .from_table(RecipeUser::Table)
-        .and_where(Expr::col(RecipeUser::Id).eq(&event.aggregator_id))
-        .build_sqlx(SqliteQueryBuilder);
-
-    sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
-        .execute(&w)
-        .await?;
-    Ok(())
 }
 
 #[evento::subscription]

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -1,5 +1,5 @@
 use evento::{
-    AggregatorExecutor, Cursor, Executor, Projection, Snapshot,
+    Cursor, Executor, Projection, Snapshot,
     cursor::{Args, ReadResult},
     metadata::Event,
     sql::Reader,
@@ -336,8 +336,9 @@ async fn find_user(pool: &SqlitePool, id: impl Into<String>) -> anyhow::Result<O
         .await?)
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, UserView> {
-    Projection::new::<Recipe>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, UserView> {
+    Projection::new::<Recipe>()
+        .tombstone::<Deleted>()
         .handler(handle_created())
         .handler(handle_imported())
         .handler(handle_recipe_type_changed())
@@ -364,14 +365,9 @@ pub(crate) async fn load<E: Executor>(
     write_db: &SqlitePool,
     id: impl Into<String>,
 ) -> Result<Option<UserView>, anyhow::Error> {
-    let id = id.into();
-
-    if executor.has_event::<Deleted>(&id).await? {
-        return Ok(None);
-    }
-
-    create_projection(id)
+    create_projection()
         .data((read_db.clone(), write_db.clone()))
+        .load(id)
         .execute(executor)
         .await
 }

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -474,6 +474,20 @@ impl<E: Executor> Snapshot<E> for UserView {
 
         Ok(())
     }
+
+    async fn drop_snapshot(
+        context: &evento::projection::Context<'_, E>,
+    ) -> anyhow::Result<()> {
+        let (_, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
+        let (sql, values) = Query::delete()
+            .from_table(RecipeUser::Table)
+            .and_where(Expr::col(RecipeUser::Id).eq(&context.id))
+            .build_sqlx(SqliteQueryBuilder);
+        sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
+            .execute(&write_db)
+            .await?;
+        Ok(())
+    }
 }
 
 #[evento::handler]

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -475,9 +475,7 @@ impl<E: Executor> Snapshot<E> for UserView {
         Ok(())
     }
 
-    async fn drop_snapshot(
-        context: &evento::projection::Context<'_, E>,
-    ) -> anyhow::Result<()> {
+    async fn drop_snapshot(context: &evento::projection::Context<'_, E>) -> anyhow::Result<()> {
         let (_, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
         let (sql, values) = Query::delete()
             .from_table(RecipeUser::Table)

--- a/crates/core/src/recipe/root/delete.rs
+++ b/crates/core/src/recipe/root/delete.rs
@@ -1,5 +1,5 @@
-use evento::{Executor, ProjectionAggregator};
-use imkitchen_types::recipe::Deleted;
+use evento::{Aggregator, Executor, ProjectionAggregator};
+use imkitchen_types::recipe::{self, Deleted};
 
 impl<E: Executor> super::Module<E> {
     pub async fn delete(
@@ -7,7 +7,8 @@ impl<E: Executor> super::Module<E> {
         id: impl Into<String>,
         request_by: impl Into<String>,
     ) -> crate::Result<()> {
-        let Some(recipe) = self.load(id).await? else {
+        let id = id.into();
+        let Some(recipe) = self.load(&id).await? else {
             crate::not_found!("recipe");
         };
 
@@ -21,6 +22,10 @@ impl<E: Executor> super::Module<E> {
             .event(&Deleted)
             .requested_by(request_by)
             .commit(&self.executor)
+            .await?;
+
+        self.executor
+            .delete_snapshot(recipe::Recipe::aggregator_type().to_owned(), id)
             .await?;
 
         Ok(())

--- a/crates/core/src/recipe/root/mod.rs
+++ b/crates/core/src/recipe/root/mod.rs
@@ -123,7 +123,7 @@ async fn handle_all_made_private(
 
 pub fn create_projection<E: Executor>() -> Projection<E, Recipe> {
     Projection::new::<recipe::Recipe>()
-        .revision(1)
+        .revision(2)
         .tombstone::<Deleted>()
         .handler(handle_created())
         .handler(handle_imported())

--- a/crates/core/src/recipe/root/mod.rs
+++ b/crates/core/src/recipe/root/mod.rs
@@ -54,7 +54,7 @@ impl<E: Executor> Module<E> {
         }
     }
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<Recipe>> {
-        let Some(recipe) = create_projection(id).execute(&self.executor).await? else {
+        let Some(recipe) = create_projection().load(id).execute(&self.executor).await? else {
             return Ok(None);
         };
 
@@ -68,7 +68,8 @@ impl<E: Executor> Module<E> {
     pub async fn load_share(&self, user_id: impl Into<String>) -> anyhow::Result<RecipeShareState> {
         let user_id = user_id.into();
 
-        Ok(create_share_projection(&user_id)
+        Ok(create_share_projection()
+            .load(&user_id)
             .execute(&self.executor)
             .await?
             .unwrap_or_else(|| RecipeShareState {
@@ -98,10 +99,8 @@ pub struct RecipeShareState {
     pub id: String,
 }
 
-pub fn create_share_projection<E: Executor>(
-    user_id: impl Into<String>,
-) -> Projection<E, RecipeShareState> {
-    Projection::new::<recipe_share::RecipeShare>(user_id)
+pub fn create_share_projection<E: Executor>() -> Projection<E, RecipeShareState> {
+    Projection::new::<recipe_share::RecipeShare>()
         .handler(handle_all_shared_to_community())
         .handler(handle_all_made_private())
         .safety_check()
@@ -131,8 +130,8 @@ async fn handle_all_made_private(
     Ok(())
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Recipe> {
-    Projection::new::<recipe::Recipe>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, Recipe> {
+    Projection::new::<recipe::Recipe>()
         .revision(1)
         .handler(handle_created())
         .handler(handle_deleted())

--- a/crates/core/src/recipe/root/mod.rs
+++ b/crates/core/src/recipe/root/mod.rs
@@ -54,15 +54,7 @@ impl<E: Executor> Module<E> {
         }
     }
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<Recipe>> {
-        let Some(recipe) = create_projection().load(id).execute(&self.executor).await? else {
-            return Ok(None);
-        };
-
-        if recipe.is_deleted {
-            return Ok(None);
-        }
-
-        Ok(Some(recipe))
+        create_projection().load(id).execute(&self.executor).await
     }
 
     pub async fn load_share(&self, user_id: impl Into<String>) -> anyhow::Result<RecipeShareState> {
@@ -91,7 +83,6 @@ pub struct Recipe {
     pub advance_prep_hash: Vec<u8>,
     pub accepts_accompaniment: bool,
     pub is_shared: bool,
-    pub is_deleted: bool,
 }
 
 #[evento::projection(Encode, Decode)]
@@ -133,8 +124,8 @@ async fn handle_all_made_private(
 pub fn create_projection<E: Executor>() -> Projection<E, Recipe> {
     Projection::new::<recipe::Recipe>()
         .revision(1)
+        .tombstone::<Deleted>()
         .handler(handle_created())
-        .handler(handle_deleted())
         .handler(handle_imported())
         .handler(handle_made_private())
         .handler(handle_ingredients_changed())
@@ -345,13 +336,6 @@ async fn handle_shared_to_community(
 #[evento::handler]
 async fn handle_made_private(_event: Event<MadePrivate>, data: &mut Recipe) -> anyhow::Result<()> {
     data.is_shared = false;
-
-    Ok(())
-}
-
-#[evento::handler]
-async fn handle_deleted(_event: Event<Deleted>, data: &mut Recipe) -> anyhow::Result<()> {
-    data.is_deleted = true;
 
     Ok(())
 }

--- a/crates/core/src/shopping/root/mod.rs
+++ b/crates/core/src/shopping/root/mod.rs
@@ -31,7 +31,7 @@ impl<E: Executor> Module<E> {
     }
 
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<Shopping>> {
-        create_projection(id).execute(&self.executor).await
+        create_projection().load(id).execute(&self.executor).await
     }
 }
 
@@ -51,8 +51,8 @@ impl ProjectionAggregator for Shopping {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Shopping> {
-    Projection::new::<shopping::Shopping>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, Shopping> {
+    Projection::new::<shopping::Shopping>()
         .handler(handle_checked())
         .handler(handle_generated())
         .handler(handle_unchecked())

--- a/crates/core/tests/recipe/delete.rs
+++ b/crates/core/tests/recipe/delete.rs
@@ -10,8 +10,7 @@ async fn test_delete() -> anyhow::Result<()> {
     let cmd = imkitchen_core::recipe::Module::new(state);
 
     let recipe_id = cmd.create("john", "john_doe".to_owned()).await?;
-    let recipe = cmd.load(&recipe_id).await?.unwrap();
-    assert!(!recipe.is_deleted);
+    assert!(cmd.load(&recipe_id).await?.is_some());
 
     cmd.delete(&recipe_id, "john").await?;
 

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -7,5 +7,5 @@ pub(crate) mod query;
 pub(crate) mod repository;
 mod root;
 
-pub use query::{admin, global_stat, login, query_subscription};
+pub use query::{admin, global_stat, login};
 pub use root::*;

--- a/crates/identity/src/meal_preferences/mod.rs
+++ b/crates/identity/src/meal_preferences/mod.rs
@@ -23,7 +23,8 @@ impl<E: Executor> Module<E> {
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<MealPreferences> {
         let id = id.into();
 
-        create_projection::<E>(&id)
+        create_projection::<E>()
+            .load(&id)
             .execute(&self.executor)
             .await
             .map(|r| {
@@ -46,8 +47,8 @@ pub struct MealPreferences {
     pub cuisine_variety_weight: f32,
 }
 
-fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, MealPreferences> {
-    Projection::new::<meal_preferences::MealPreferences>(id)
+fn create_projection<E: Executor>() -> Projection<E, MealPreferences> {
+    Projection::new::<meal_preferences::MealPreferences>()
         .handler(handle_updated())
         .safety_check()
 }

--- a/crates/identity/src/password/mod.rs
+++ b/crates/identity/src/password/mod.rs
@@ -24,7 +24,7 @@ impl<E: Executor> Deref for Module<E> {
 
 impl<E: Executor> Module<E> {
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<Password>> {
-        create_projection(id).execute(&self.executor).await
+        create_projection().load(id).execute(&self.executor).await
     }
 }
 
@@ -36,8 +36,8 @@ pub struct Password {
     pub expire_at: u64,
 }
 
-fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Password> {
-    Projection::new::<password::Password>(id)
+fn create_projection<E: Executor>() -> Projection<E, Password> {
+    Projection::new::<password::Password>()
         .handler(handle_reset_requested())
         .handler(handle_reset_completed())
         .safety_check()

--- a/crates/identity/src/query/admin.rs
+++ b/crates/identity/src/query/admin.rs
@@ -33,9 +33,10 @@ pub(crate) async fn load<E: Executor>(
 ) -> Result<Option<AdminView>, anyhow::Error> {
     let id = id.into();
 
-    create_projection(&id)
-        .aggregator::<Subscription>(id)
+    create_projection()
         .data((read_db.clone(), write_db.clone()))
+        .load(&id)
+        .aggregator::<Subscription>(id)
         .execute(executor)
         .await
 }
@@ -211,8 +212,8 @@ impl<E: Executor> crate::Module<E> {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, AdminView> {
-    Projection::new::<User>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, AdminView> {
+    Projection::new::<User>()
         .handler(handle_actived())
         .handler(handle_susended())
         .handler(handle_made_admin())

--- a/crates/identity/src/query/login.rs
+++ b/crates/identity/src/query/login.rs
@@ -21,8 +21,10 @@ impl<E: Executor> crate::Module<E> {
     ) -> Result<Option<LoginView>, anyhow::Error> {
         let id = id.into();
 
-        create_projection(&id)
+        create_projection()
             .data((self.read_db.clone(), self.write_db.clone()))
+            .load(&id)
+            .aggregator::<Subscription>(id)
             .execute(&self.executor)
             .await
     }
@@ -71,11 +73,8 @@ impl Login {
     }
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, LoginView> {
-    let id = id.into();
-
-    Projection::new::<User>(&id)
-        .aggregator::<Subscription>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, LoginView> {
+    Projection::new::<User>()
         .handler(handle_logged_in())
         .handler(handle_logout())
         .handler(handle_actived())

--- a/crates/identity/src/query/mod.rs
+++ b/crates/identity/src/query/mod.rs
@@ -1,27 +1,3 @@
-use crate::types::user::Registered;
-use evento::{
-    Executor,
-    metadata::RawEvent,
-    subscription::{Context, SubscriptionBuilder},
-};
-use sqlx::SqlitePool;
-
 pub mod admin;
 pub mod global_stat;
 pub mod login;
-
-pub fn query_subscription<E: Executor>() -> SubscriptionBuilder<E> {
-    SubscriptionBuilder::new("user-query")
-        .handler(handle_user_all())
-        .safety_check()
-}
-
-#[evento::subscription_all]
-async fn handle_user_all<E: Executor>(
-    context: &Context<'_, E>,
-    event: RawEvent<Registered>,
-) -> anyhow::Result<()> {
-    let (r, w) = context.extract::<(SqlitePool, SqlitePool)>();
-    admin::load(context.executor, &r, &w, &event.aggregator_id).await?;
-    Ok(())
-}

--- a/crates/identity/src/root/mod.rs
+++ b/crates/identity/src/root/mod.rs
@@ -49,7 +49,7 @@ impl<E: Executor> Module<E> {
         }
     }
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<Option<User>> {
-        create_projection(id).execute(&self.executor).await
+        create_projection().load(id).execute(&self.executor).await
     }
 
     pub async fn find_email(
@@ -71,8 +71,8 @@ pub struct User {
     pub state: State,
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, User> {
-    Projection::new::<user::User>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, User> {
+    Projection::new::<user::User>()
         .handler(handle_registered())
         .handler(handle_actived())
         .handler(handle_susended())

--- a/crates/identity/src/user_profile/mod.rs
+++ b/crates/identity/src/user_profile/mod.rs
@@ -21,7 +21,8 @@ impl<E: Executor> Module<E> {
     pub async fn load(&self, id: impl Into<String>) -> anyhow::Result<UserProfile> {
         let id = id.into();
 
-        create_projection::<E>(&id)
+        create_projection::<E>()
+            .load(&id)
             .execute(&self.executor)
             .await
             .map(|r| {
@@ -40,8 +41,8 @@ pub struct UserProfile {
     pub description: String,
 }
 
-fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, UserProfile> {
-    Projection::new::<user_profile::UserProfile>(id)
+fn create_projection<E: Executor>() -> Projection<E, UserProfile> {
+    Projection::new::<user_profile::UserProfile>()
         .handler(handle_changed())
         .safety_check()
 }

--- a/crates/notification/src/recipient.rs
+++ b/crates/notification/src/recipient.rs
@@ -33,8 +33,8 @@ pub struct Recipient {
     pub timezone: String,
 }
 
-pub fn create_projection<E: Executor>(id: impl Into<String>) -> Projection<E, Recipient> {
-    Projection::new::<user::User>(id)
+pub fn create_projection<E: Executor>() -> Projection<E, Recipient> {
+    Projection::new::<user::User>()
         .handler(handle_registered())
         .handler(handle_logged_in())
 }
@@ -51,8 +51,9 @@ pub(crate) async fn load<E: Executor>(
     write_db: &SqlitePool,
     id: impl Into<String>,
 ) -> anyhow::Result<Option<Recipient>> {
-    create_projection(id)
+    create_projection()
         .data((read_db.clone(), write_db.clone()))
+        .load(id)
         .execute(executor)
         .await
 }

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -90,11 +90,6 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
-    let sub_recipe_root = imkitchen_core::recipe::create_projection()
-        .subscription("recipe-root")
-        .start(&executor)
-        .await?;
-
     let sub_recipe_query = imkitchen_core::recipe::query::user::create_projection()
         .data((read_pool.clone(), write_pool.clone()))
         .subscription("recipe-query")
@@ -247,7 +242,6 @@ pub async fn serve(
         sub_contact_query.shutdown(),
         sub_contact_global_stat.shutdown(),
         sub_recipe_command.shutdown(),
-        sub_recipe_root.shutdown(),
         sub_recipe_query.shutdown(),
         sub_recipe_query_share.shutdown(),
         sub_recipe_user_fts.shutdown(),

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -52,8 +52,9 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
-    let sub_user_query = imkitchen_identity::query_subscription()
+    let sub_user_query = imkitchen_identity::admin::create_projection()
         .data((read_pool.clone(), write_pool.clone()))
+        .subscription("user-query")
         .start(&executor)
         .await?;
 
@@ -73,8 +74,9 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
-    let sub_contact_query = imkitchen_core::contact::query_subscription()
+    let sub_contact_query = imkitchen_core::contact::admin::create_projection()
         .data((read_pool.clone(), write_pool.clone()))
+        .subscription("contact-query")
         .start(&executor)
         .await?;
 
@@ -88,7 +90,13 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
-    let sub_recipe_query = imkitchen_core::recipe::query::subscription()
+    let sub_recipe_query = imkitchen_core::recipe::query::user::create_projection()
+        .data((read_pool.clone(), write_pool.clone()))
+        .subscription("recipe-query")
+        .start(&executor)
+        .await?;
+
+    let sub_recipe_query_share = imkitchen_core::recipe::query::subscription()
         .data((read_pool.clone(), write_pool.clone()))
         .start(&executor)
         .await?;
@@ -235,6 +243,7 @@ pub async fn serve(
         sub_contact_global_stat.shutdown(),
         sub_recipe_command.shutdown(),
         sub_recipe_query.shutdown(),
+        sub_recipe_query_share.shutdown(),
         sub_recipe_user_fts.shutdown(),
         sub_recipe_user_stat.shutdown(),
         sub_recipe_thumbnail.shutdown(),

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -90,6 +90,11 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
+    let sub_recipe_root = imkitchen_core::recipe::create_projection()
+        .subscription("recipe-root")
+        .start(&executor)
+        .await?;
+
     let sub_recipe_query = imkitchen_core::recipe::query::user::create_projection()
         .data((read_pool.clone(), write_pool.clone()))
         .subscription("recipe-query")
@@ -242,6 +247,7 @@ pub async fn serve(
         sub_contact_query.shutdown(),
         sub_contact_global_stat.shutdown(),
         sub_recipe_command.shutdown(),
+        sub_recipe_root.shutdown(),
         sub_recipe_query.shutdown(),
         sub_recipe_query_share.shutdown(),
         sub_recipe_user_fts.shutdown(),


### PR DESCRIPTION
## Summary
- Bumps the `evento` workspace dep to `2.0.0-alpha.19` (published release for [timayz/evento#198](https://github.com/timayz/evento/pull/198)).
- Adapts every `create_projection` callsite to the new id-less projection API: `Projection::new::<A>(id)` → `Projection::new::<A>().load(id)`, `Projection::ids(vec)` → `Projection::new().load_ids(vec)`, and `.aggregator::<X>(id)` moves from the projection definition to the `LoadBuilder`.
- Replaces three hand-rolled `#[evento::subscription_all]` "load on every aggregate event" handlers with declarative `Projection::subscription("...")`:
  - `contact-query` / `user-query`: clean swap, no tombstone.
  - `recipe-query`: adds `.tombstone::<Deleted>()`, overrides `Snapshot::drop_snapshot` on `UserView` to delete the `recipe_user` row, splits the `RecipeShare` fan-out handlers into a new `recipe-query-share` subscription.
- `recipe::root::Recipe` projection gets `.tombstone::<Deleted>()` too. Drops the manual `is_deleted: bool` flag + `handle_deleted` handler + post-load check in `Module::load`. Snapshot revision bumped to 2 since the struct layout changed. The delete command explicitly calls `executor.delete_snapshot(...)` after committing — cleaner than running a permanent background subscription just for cleanup.

## Test plan
- [x] `cargo check --workspace --tests`
- [x] `cargo clippy --workspace --tests` (clean)
- [x] `cargo test --workspace` (all passing — 22 tests)
- [ ] Note: `recipe-query-share` is a new subscription key — backfills from event zero on first deploy. Handlers are idempotent SQL updates so the replay is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)