### PR TITLE
fix(ui): prevent unnecessary scroll on cooking screen first paint

### DIFF
--- a/templates/cooking.html
+++ b/templates/cooking.html
@@ -8,7 +8,7 @@
      on the #cooking-screen element below. These static rules just read them. */
   .cooking-screen {
     background: radial-gradient(ellipse at 50% 0%, var(--tint-soft), var(--color-cream) 70%);
-    height: 100dvh;
+    height: 100svh;
   }
   .cooking-plate {
     background:


### PR DESCRIPTION
## Summary

On mobile, the cooking screen showed an unnecessary document scroll on first open. Tapping Next/Prev fixed it, and it stayed correct afterward.

The cause is the mobile `dvh` initial-paint quirk: `100dvh` resolves to the *large* viewport before the browser settles, making `.cooking-screen` taller than the visible area → the document scrolls. The Next/Prev tap forces a recalculation (and TwinSpark `replace`-swaps the element), so later renders fit.

## Fix

Use `100svh` instead of `100dvh` for the cooking screen height. `100svh` is always bounded by the smallest viewport, so it fits on the very first paint. Since only the inner `<main>` scrolls (the document stays pinned), the URL bar never retracts to leave a gap.

## Test plan

- [ ] Open a cooking screen on mobile — no document scroll on first paint
- [ ] Tap Next / Prev — still no document scroll, no gap at the bottom
- [ ] Inner step instructions still scroll within `<main>` when long

🤖 Generated with [Claude Code](https://claude.com/claude-code)