### PR TITLE
fix(deps): pin time to <0.3.48 to fix cookie build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_builder"
@@ -6210,11 +6213,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
@@ -6225,15 +6229,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,10 @@ sea-query = { version = "1.0.1", default-features = false, features = ["derive",
 sea-query-sqlx = { version = "0.9.1", features = ["runtime-tokio", "sqlx-sqlite", "with-json"] }
 async-trait = "0.1"
 futures = "0.3"
-time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
+# Pinned to <0.3.48: time 0.3.48 introduced a trait impl that conflicts with
+# cookie 0.18.1 (via axum-extra), breaking the build with E0119. 0.3.47 is the
+# minimum required by simple_asn1 (via jsonwebtoken), so it's the only working version.
+time = { version = ">=0.3.47, <0.3.48", features = ["formatting", "parsing", "macros"] }
 strum = { version = "0.28", features = ["derive"] }
 sha3 = "0.12"
 temp-dir = "0.2"

--- a/crates/identity/src/query/admin.rs
+++ b/crates/identity/src/query/admin.rs
@@ -94,7 +94,9 @@ impl AdminView {
             return "".to_owned();
         };
 
-        let Ok(format) = time::format_description::parse("[month repr:short] [day], [year]") else {
+        let Ok(format) =
+            time::format_description::parse_borrowed::<2>("[month repr:short] [day], [year]")
+        else {
             return "".to_owned();
         };
 


### PR DESCRIPTION
## Summary

The Docker release build (`cargo build --release --bin imkitchen`) was failing with:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>` ...
  --> cookie-0.18.1/src/expiration.rs:129:1
  = note: conflicting implementation in crate `time`
error: could not compile `cookie` (lib) due to 1 previous error
```

`time 0.3.48` introduced a trait impl that collides with `cookie 0.18.1`'s blanket `impl<T: Into<Option<OffsetDateTime>>> From<T> for Expiration`. `cookie 0.18.1` is the latest release (pulled in transitively via `axum-extra`), so the fix has to be on the `time` side.

## Fix

- Pin `time` to `>=0.3.47, <0.3.48` in the workspace `Cargo.toml`. `0.3.47` is the minimum required by `simple_asn1` (via `jsonwebtoken`), so it's the only version satisfying both constraints. Verified `cookie 0.18.1` compiles cleanly against `time 0.3.47`.
- Replace the deprecated `time::format_description::parse` with `parse_borrowed::<2>` in `crates/identity/src/query/admin.rs`, clearing the `#[warn(deprecated)]` warning from the same build.

## Test plan

- [x] `cargo build --release --bin imkitchen` — finishes clean (no E0119, no deprecation warning)
- [ ] Docker image build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)