### PR TITLE
fix(deps): update all non-major

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6510,9 +6510,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
  "bitflags 2.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,20 +3600,20 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126fa21513275eca9dd1e9a7d21602e33d3b9449bde2a55d4c3090970c4d1f78"
+checksum = "e79f881ca20da66c0599a516cf963be43400c4ad282d8bb7f67438a4d4d15320"
 dependencies = [
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_codegen 0.135.0",
- "oxc_diagnostics 0.135.0",
- "oxc_mangler 0.135.0",
- "oxc_minifier 0.135.0",
- "oxc_parser 0.135.0",
- "oxc_regular_expression 0.135.0",
- "oxc_span 0.135.0",
- "oxc_syntax 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_codegen 0.136.0",
+ "oxc_diagnostics 0.136.0",
+ "oxc_mangler 0.136.0",
+ "oxc_minifier 0.136.0",
+ "oxc_parser 0.136.0",
+ "oxc_regular_expression 0.136.0",
+ "oxc_span 0.136.0",
+ "oxc_syntax 0.136.0",
 ]
 
 [[package]]
@@ -3651,7 +3651,22 @@ checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
  "cfg-if",
  "owo-colors",
- "oxc-miette-derive",
+ "oxc-miette-derive 2.7.1",
+ "textwrap",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "oxc-miette"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b776084bf11ad750806cb63f9ed2606a12ab374cf458f36a7731eba1f5d753fc"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "oxc-miette-derive 3.0.0",
  "textwrap",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -3663,6 +3678,17 @@ name = "oxc-miette-derive"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3684,13 +3710,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d732c2d8df8067a8d7417be81a8a4631e3201ad420ae70aa2426aebf7bc0326"
+checksum = "2ff1abde02d06e45daee3f095b633c30bb9ad38607c6d9f22cce70c2ff38d62c"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
- "oxc_data_structures 0.135.0",
+ "oxc_data_structures 0.136.0",
  "rustc-hash",
 ]
 
@@ -3713,20 +3739,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29512a9acf168a734cbead68ae798c07102b9ecb897cdbe17a40d327b5fff2ec"
+checksum = "9d5b4c5dbe671c26ebba9e81d8632a8c4288b507f1b69210db87961fa6dc042a"
 dependencies = [
  "bitflags 2.13.0",
- "oxc_allocator 0.135.0",
- "oxc_ast_macros 0.135.0",
- "oxc_data_structures 0.135.0",
- "oxc_diagnostics 0.135.0",
- "oxc_estree 0.135.0",
- "oxc_regular_expression 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast_macros 0.136.0",
+ "oxc_data_structures 0.136.0",
+ "oxc_diagnostics 0.136.0",
+ "oxc_estree 0.136.0",
+ "oxc_regular_expression 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
 ]
 
 [[package]]
@@ -3743,9 +3769,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06186227ab1f27f214d824030ef8d7abd604fb24cd647d2acfebfe6bbe378dc6"
+checksum = "2a241ebde1bbe9328fb134abe933176f09b89decb6aa6047200436c241505c74"
 dependencies = [
  "phf 0.13.1",
  "proc-macro2",
@@ -3767,14 +3793,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8a8771bbedc5904b6536822fb719f76291d00ab2bccbf5f98950d666f0154f"
+checksum = "2ca2672d986140e9c03c473203cdb4630f6cc704cddfd6cb753ea770284944bc"
 dependencies = [
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_span 0.135.0",
- "oxc_syntax 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_span 0.136.0",
+ "oxc_syntax 0.136.0",
 ]
 
 [[package]]
@@ -3800,23 +3826,23 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a375edc284941656da7e436e44ca223426994b98f9035ed99f57b5f36df327a5"
+checksum = "b042d9f2b2065a40f5fd69b0aee948f3db1ee5facae154275242fc4f59a095f7"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "dragonbox_ecma 0.1.12",
  "itoa",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_data_structures 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_data_structures 0.136.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.135.0",
- "oxc_sourcemap 7.0.0",
- "oxc_span 0.135.0",
+ "oxc_semantic 0.136.0",
+ "oxc_sourcemap 8.0.1",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
 ]
 
@@ -3835,13 +3861,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4134154f80f0b95fe891f3cfbf4936fc8f22817f4649977ef6d6f14518e7ecd2"
+checksum = "c6bba8c18ebfa685b289ab434e1215f8945a885344905fdcf8610aeaa559178e"
 dependencies = [
  "cow-utils",
  "oxc-browserslist 3.0.4",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
  "serde",
 ]
@@ -3854,9 +3880,9 @@ checksum = "dd090988aa69c1e394f424289abb9bb1281448a072419ca556a07228ad36b854"
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46270ed833a7d2e5f5fbf0c51f970c2d7e1ef09356d40798cf4702f7d2dae30d"
+checksum = "0701d254926331257e9be93d6d2937390b93f5bbdf6243f73e3128b0d2bb8f54"
 
 [[package]]
 name = "oxc_diagnostics"
@@ -3865,18 +3891,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b8a09558d38ee7f23faf0249cdb37b5b26f53a7375941f8636c41c661b283ce"
 dependencies = [
  "cow-utils",
- "oxc-miette",
+ "oxc-miette 2.7.1",
  "percent-encoding",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ebb338486583af9e603f4d20be123ad3ae52a5415265454995020386d8afe"
+checksum = "2daf5f7aede9a68b8d9ea28907632f860e284aca9862f2fee0deff288d16aff5"
 dependencies = [
  "cow-utils",
- "oxc-miette",
+ "oxc-miette 3.0.0",
  "percent-encoding",
 ]
 
@@ -3897,18 +3923,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef5f3e346539b48dbda9d0b618021ba6bb781f7a192476e4bf9b18df7ccaab4"
+checksum = "1cb2763772878505ba1d0bcc2931adc4161374791933105e095f917c34230f5f"
 dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_regular_expression 0.135.0",
- "oxc_span 0.135.0",
- "oxc_syntax 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_regular_expression 0.136.0",
+ "oxc_span 0.136.0",
+ "oxc_syntax 0.136.0",
 ]
 
 [[package]]
@@ -3919,9 +3945,9 @@ checksum = "af85b24b7e10bf0ccb252f16d38492f51236c1ba146f62013993667cbf7fa649"
 
 [[package]]
 name = "oxc_estree"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816dfd17df8b02a45b122a1f7bb3c1486d4392e0163aea0e6334ad3894a7ea6b"
+checksum = "d972254295a3200aabef1fc7dd382694e1664afadd6962a3d0e1f82550310d9a"
 
 [[package]]
 name = "oxc_index"
@@ -3962,19 +3988,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af362ebcb00395e4eaf2c5a158a65f76c3962d2f50d4af7d9d0c763426335803"
+checksum = "181e65298a369dd19537f8403fdb527a07067c6a1ce9f3f5bb7c65cc3f75ec94"
 dependencies = [
  "itertools 0.14.0",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_data_structures 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_data_structures 0.136.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_semantic 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
 ]
 
@@ -4005,27 +4031,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8873a4b6bac638cd818eb8a81ca06352d8217cdad1ef561b6eedcf7b83bf88"
+checksum = "aba156400756c8e929948bdf6ca7b1b5532f0764187063f1517f1bd1094e357a"
 dependencies = [
  "cow-utils",
  "itoa",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_ast_visit 0.135.0",
- "oxc_compat 0.135.0",
- "oxc_data_structures 0.135.0",
- "oxc_ecmascript 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_ast_visit 0.136.0",
+ "oxc_compat 0.136.0",
+ "oxc_data_structures 0.136.0",
+ "oxc_ecmascript 0.136.0",
  "oxc_index 5.0.0",
- "oxc_mangler 0.135.0",
- "oxc_parser 0.135.0",
- "oxc_regular_expression 0.135.0",
- "oxc_semantic 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_mangler 0.136.0",
+ "oxc_parser 0.136.0",
+ "oxc_regular_expression 0.136.0",
+ "oxc_semantic 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
- "oxc_traverse 0.135.0",
+ "oxc_syntax 0.136.0",
+ "oxc_traverse 0.136.0",
  "rustc-hash",
 ]
 
@@ -4054,24 +4080,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cb9af99a1d02989ed53780e3b2b67757226d4501365e65781ae4519be150b6"
+checksum = "fbc60cb7bd0571a91d4b887bbc4ffc47bc662cb8ae3ff1025679690572072968"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_data_structures 0.135.0",
- "oxc_diagnostics 0.135.0",
- "oxc_ecmascript 0.135.0",
- "oxc_regular_expression 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_data_structures 0.136.0",
+ "oxc_diagnostics 0.136.0",
+ "oxc_ecmascript 0.136.0",
+ "oxc_regular_expression 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
  "seq-macro",
 ]
@@ -4094,15 +4120,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfe28ec0ffa88784155900d5b7ea1f8383f69d80659ed86f1c4a18a6f117488"
+checksum = "c5b0cc5a451ebfe951a680ca2407e9ca9fcb2c827be1d94291dcd07ceaf0c539"
 dependencies = [
  "bitflags 2.13.0",
- "oxc_allocator 0.135.0",
- "oxc_ast_macros 0.135.0",
- "oxc_diagnostics 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast_macros 0.136.0",
+ "oxc_diagnostics 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
  "phf 0.13.1",
  "rustc-hash",
@@ -4132,21 +4158,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6735efd98d54e0f5e8c30a6b17df921085373d54b2b1e10e42d7f4ec8d2597bc"
+checksum = "01cc7ba86610d560bd6ef0b62286c0ea77d1f813e05fa56ee3b27adda1474035"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_ast_visit 0.135.0",
- "oxc_diagnostics 0.135.0",
- "oxc_ecmascript 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_ast_visit 0.136.0",
+ "oxc_data_structures 0.136.0",
+ "oxc_diagnostics 0.136.0",
+ "oxc_ecmascript 0.136.0",
  "oxc_index 5.0.0",
- "oxc_span 0.135.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
  "self_cell",
  "smallvec",
@@ -4167,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3866f9075027840e0711b52e15d2e1ba076fc5f5f01c96eeedd26375410641"
+checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
 dependencies = [
  "base64-simd 0.8.0",
  "json-escape-simd",
@@ -4185,7 +4212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71243fe1ece27f71a6be5e2ab11d051792eeb578f3b056d7c9bbe82ec8043bf3"
 dependencies = [
  "compact_str",
- "oxc-miette",
+ "oxc-miette 2.7.1",
  "oxc_allocator 0.95.0",
  "oxc_ast_macros 0.95.0",
  "oxc_estree 0.95.0",
@@ -4193,28 +4220,28 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fbd1667674fd9c25e079a0ab84a87b26e2946d1ce86ad6c5827afa0518c493"
+checksum = "189ad3c3c0b7bd7f4710f8efbfb277565e1f171c1ebc0298ec5d530c0d1a1fbb"
 dependencies = [
  "compact_str",
- "oxc-miette",
- "oxc_allocator 0.135.0",
- "oxc_ast_macros 0.135.0",
- "oxc_estree 0.135.0",
+ "oxc-miette 3.0.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast_macros 0.136.0",
+ "oxc_estree 0.136.0",
  "oxc_str",
 ]
 
 [[package]]
 name = "oxc_str"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887823468316c2b4798275976857edeb0574201a944810f2f94f3d79aaf6187e"
+checksum = "7b77bc4ed1133165825c5408e9f469c0bebb500b7dedda4225246c5111906ceb"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
- "oxc_allocator 0.135.0",
- "oxc_estree 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_estree 0.136.0",
 ]
 
 [[package]]
@@ -4239,19 +4266,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad8963ea5ad880d3185db2f8a50809e3a10772c2762500518229bca5347be04"
+checksum = "c1a3c4fabd8698f647082094643d4e467453b1ea14bab059173b14f48630f5b4"
 dependencies = [
  "bitflags 2.13.0",
  "cow-utils",
  "dragonbox_ecma 0.1.12",
  "nonmax",
- "oxc_allocator 0.135.0",
- "oxc_ast_macros 0.135.0",
- "oxc_estree 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast_macros 0.136.0",
+ "oxc_estree 0.136.0",
  "oxc_index 5.0.0",
- "oxc_span 0.135.0",
+ "oxc_span 0.136.0",
  "oxc_str",
  "phf 0.13.1",
  "unicode-id-start",
@@ -4277,20 +4304,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.135.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e03d0cb61b3c0d0094a328e47d14649c8d00559544cd16ee0861b1771af7d01"
+checksum = "11130b7efa29a53baaee4f32ff034ecb35f80d7d845a78db5726c9cf65ec7ddd"
 dependencies = [
  "itoa",
- "oxc_allocator 0.135.0",
- "oxc_ast 0.135.0",
- "oxc_ast_visit 0.135.0",
- "oxc_data_structures 0.135.0",
- "oxc_ecmascript 0.135.0",
- "oxc_semantic 0.135.0",
- "oxc_span 0.135.0",
+ "oxc_allocator 0.136.0",
+ "oxc_ast 0.136.0",
+ "oxc_ast_visit 0.136.0",
+ "oxc_data_structures 0.136.0",
+ "oxc_ecmascript 0.136.0",
+ "oxc_semantic 0.136.0",
+ "oxc_span 0.136.0",
  "oxc_str",
- "oxc_syntax 0.135.0",
+ "oxc_syntax 0.136.0",
  "rustc-hash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1450,7 +1450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "evento"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe70d03785849f05c1390527c4fc385341ccaa5d5d6ec011c97b5c78f3291e6"
+checksum = "d06291bbe45a30f5b19ba1ca699d59e89b4c0bb3e0aeeda2a017a79341db381f"
 dependencies = [
  "evento-core",
  "evento-sql",
@@ -1703,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "evento-core"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bf45b4a5ef5ea5e2fd68ec7352f46e723a7951515475f18a872f3eb9b38a70"
+checksum = "c3c1b2ba269a6a06112e4691063277c12256d7a8a1c57241254fa0f80aad4557"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1724,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "evento-macro"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e7691f6cf7ef5b39b8740195886f28b5d1c52e5a38a64b5dc69e60c28c92b5"
+checksum = "6c7352b1e395ff51d2156c94e3686dba164b98640cfedd8244edaa31938c62ad"
 dependencies = [
  "convert_case 0.11.0",
  "quote",
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4953678df37fc0461987dfface9558c098ee5572bd39e013d14e1f009f2f71"
+checksum = "86178678ddf8743f413f9e82e0e2f6a607829a241012e6bf50e1e25850248a21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql-migrator"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e712da78e2092ff1cd5c2e973b91270345768e3b710f18e57d8f7574ce2294"
+checksum = "093318ad515e24c505b50719acdd661d0b30c98c16a541a3cef250e89a9d6382"
 dependencies = [
  "async-trait",
  "evento-sql",
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,9 +1408,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -6240,12 +6237,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
@@ -6256,15 +6252,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ urlencoding = "2.1"
 base64 = "0.22"
 url = "2.5"
 minify-html = "0.18"
-oxc = { version = "0.135.0", features = ["minifier", "codegen"] }
+oxc = { version = "0.136.0", features = ["minifier", "codegen"] }
 lightningcss = { version = "1.0.0-alpha.71", default-features = false }
 ulid = "1.2"
 sea-query = { version = "1.0.1", default-features = false, features = ["derive", "audit", "backend-sqlite"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ askama = "0.16"
 world-tax = "0.5"
 sqlx = { version = "0.9", default-features = false, features = ["migrate", "json", "derive", "runtime-tokio", "sqlite"] }
 sqlx_migrator = { version = "0.19", features = ["sqlite"] }
-evento = { version = "2.0.0-alpha.20", features = ["sqlite", "rw"] }
+evento = { version = "2.0.0-alpha.21", features = ["sqlite", "rw"] }
 argon2 = { version = "0.5", features = ["std"] }
 jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 lettre = { version = "0.11", features = ["rustls-tls", "builder"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ axum = { version = "0.8", features = ["macros", "multipart"] }
 axum-extra = { version = "0.12", features = ["cookie", "form", "query", "typed-header"] }
 webp = "0.3"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["fs", "trace", "limit", "compression-br", "compression-gzip"] }
+tower-http = { version = "0.7", features = ["fs", "trace", "limit", "compression-br", "compression-gzip"] }
 rust-i18n = "4.1"
 time-tz = "3.0.0-rc.5.0.0"
 askama = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sea-query = { version = "1.0.1", default-features = false, features = ["derive",
 sea-query-sqlx = { version = "0.9.1", features = ["runtime-tokio", "sqlx-sqlite", "with-json"] }
 async-trait = "0.1"
 futures = "0.3"
-time = { version = ">=0.3.47, <0.3.48", features = ["formatting", "parsing", "macros"] }
+time = { version = "0.3.49", features = ["formatting", "parsing", "macros"] }
 strum = { version = "0.28", features = ["derive"] }
 sha3 = "0.12"
 temp-dir = "0.2"

--- a/crates/billing/src/invoice.rs
+++ b/crates/billing/src/invoice.rs
@@ -3,7 +3,7 @@ use crate::types::{
     subscription::{Address, StripePaymentIntentSucceeded},
 };
 use evento::{
-    Aggregator, AggregatorEvent, Executor, ReadAggregator,
+    Aggregate, AggregateEvent, Executor, EventFilter,
     cursor::Args,
     metadata::Event,
     subscription::{Context, SubscriptionBuilder},
@@ -29,8 +29,8 @@ async fn handler_payment_intent_succeeded<E: Executor>(
     let result = context
         .executor
         .read(
-            Some(vec![ReadAggregator::event(
-                Created::aggregator_type(),
+            Some(vec![EventFilter::by_event(
+                Created::aggregate_type(),
                 Created::event_name(),
             )]),
             None,

--- a/crates/billing/src/invoice.rs
+++ b/crates/billing/src/invoice.rs
@@ -3,7 +3,7 @@ use crate::types::{
     subscription::{Address, StripePaymentIntentSucceeded},
 };
 use evento::{
-    Aggregate, AggregateEvent, Executor, EventFilter,
+    Aggregate, AggregateEvent, EventFilter, Executor,
     cursor::Args,
     metadata::Event,
     subscription::{Context, SubscriptionBuilder},

--- a/crates/billing/src/invoice_user.rs
+++ b/crates/billing/src/invoice_user.rs
@@ -272,7 +272,7 @@ impl<E: Executor> Snapshot<E> for InvoiceUserView {
 
 #[evento::handler]
 async fn handle_created(event: Event<Created>, data: &mut InvoiceUserView) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.invoice_number = format!("{}-{:02}", event.data.key, event.data.number);
     data.user_id = event.metadata.requested_by()?;
     data.due_at = event.data.paid_at;

--- a/crates/billing/src/scheduler.rs
+++ b/crates/billing/src/scheduler.rs
@@ -155,7 +155,7 @@ async fn handle_stripe_payment_intent_succeeded<E: Executor>(
         .into_table(UserSubscription::Table)
         .columns([UserSubscription::Id, UserSubscription::ExpireAt])
         .values_panic([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.data.expire_at.into(),
         ])
         .on_conflict(
@@ -181,7 +181,7 @@ async fn handle_cancelled<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     let statement = Query::delete()
         .from_table(UserSubscription::Table)
-        .and_where(Expr::col(UserSubscription::Id).eq(&event.aggregator_id))
+        .and_where(Expr::col(UserSubscription::Id).eq(&event.aggregate_id))
         .to_owned();
 
     let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);

--- a/crates/billing/src/subscription/cancel.rs
+++ b/crates/billing/src/subscription/cancel.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::Cancelled;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn cancel(&self, request_by: impl Into<String>) -> imkitchen_core::Result<()> {
@@ -8,7 +8,7 @@ impl<E: Executor> super::Module<E> {
 
         if subscription.is_active {
             subscription
-                .aggregator()?
+                .write()?
                 .event(&Cancelled)
                 .requested_by(request_by)
                 .commit(&self.executor)

--- a/crates/billing/src/subscription/create_stripe_customer.rs
+++ b/crates/billing/src/subscription/create_stripe_customer.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::StripeCustomerCreated;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn create_stripe_customer(
@@ -11,7 +11,7 @@ impl<E: Executor> super::Module<E> {
         let subscription = self.load(&request_by).await?;
 
         subscription
-            .aggregator()?
+            .write()?
             .event(&StripeCustomerCreated { id: id.into() })
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/billing/src/subscription/create_stripe_payment_intent.rs
+++ b/crates/billing/src/subscription/create_stripe_payment_intent.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::{PaymentDetails, StripePaymentIntentCreated};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn create_stripe_payment_intent(
@@ -14,7 +14,7 @@ impl<E: Executor> super::Module<E> {
         let subscription = self.load(&request_by).await?;
 
         subscription
-            .aggregator()?
+            .write()?
             .event(&StripePaymentIntentCreated {
                 id: id.into(),
                 email,

--- a/crates/billing/src/subscription/create_stripe_setup_intent.rs
+++ b/crates/billing/src/subscription/create_stripe_setup_intent.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::StripeSetupIntentCreated;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn create_stripe_setup_intent(
@@ -11,7 +11,7 @@ impl<E: Executor> super::Module<E> {
         let subscription = self.load(&request_by).await?;
 
         subscription
-            .aggregator()?
+            .write()?
             .event(&StripeSetupIntentCreated { id: id.into() })
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/billing/src/subscription/mod.rs
+++ b/crates/billing/src/subscription/mod.rs
@@ -73,11 +73,11 @@ fn create_projection<E: Executor>() -> Projection<E, Subscription> {
         .handler(handle_cancelled())
         .handler(handle_stripe_setup_intent_created())
         .handler(handle_stripe_setup_intent_succeeded())
-        .safety_check()
+        .strict()
 }
 
-impl evento::ProjectionAggregator for Subscription {
-    fn aggregator_id(&self) -> String {
+impl evento::ProjectionAggregate for Subscription {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
@@ -87,7 +87,7 @@ async fn handle_life_premium_toggled(
     event: Event<subscription::LifePremiumToggled>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.expire_at = event.data.expire_at;
 
     Ok(())
@@ -98,7 +98,7 @@ async fn handle_stripe_customer_created(
     event: Event<subscription::StripeCustomerCreated>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.customer_id = Some(event.data.id);
 
     Ok(())
@@ -109,7 +109,7 @@ async fn handle_stripe_payment_intent_created(
     event: Event<subscription::StripePaymentIntentCreated>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.payment_intent_id = Some(event.data.id);
     data.payment_details = Some(event.data.details);
     data.email = Some(event.data.email.to_owned());
@@ -122,7 +122,7 @@ async fn handle_stripe_setup_intent_created(
     event: Event<subscription::StripeSetupIntentCreated>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.setup_intent_id = Some(event.data.id);
 
     Ok(())
@@ -133,7 +133,7 @@ async fn handle_stripe_payment_intent_succeeded(
     event: Event<subscription::StripePaymentIntentSucceeded>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.payment_intent_id = None;
     data.payment_method_id = Some(event.data.payment_method_id);
     data.name = Some(event.data.name);
@@ -149,7 +149,7 @@ async fn handle_stripe_setup_intent_succeeded(
     event: Event<subscription::StripeSetupIntentSucceeded>,
     data: &mut Subscription,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.setup_intent_id = None;
     data.name = event.data.name;
     data.address = event.data.address;

--- a/crates/billing/src/subscription/toogle_life_premium.rs
+++ b/crates/billing/src/subscription/toogle_life_premium.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use time::UtcDateTime;
 
 use crate::types::subscription::LifePremiumToggled;
@@ -18,7 +18,7 @@ impl<E: Executor> super::Module<E> {
         };
 
         subscription
-            .aggregator()?
+            .write()?
             .event(&LifePremiumToggled {
                 expire_at: expire_at.try_into()?,
             })

--- a/crates/billing/src/subscription/update_stripe_payment_intent_status.rs
+++ b/crates/billing/src/subscription/update_stripe_payment_intent_status.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::StripePaymentIntentSucceeded;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use stripe_shared::{PaymentIntent, PaymentIntentStatus};
 use stripe_types::Expandable;
 
@@ -39,7 +39,7 @@ impl<E: Executor> super::Module<E> {
             };
 
             subscription
-                .aggregator()?
+                .write()?
                 .event(&StripePaymentIntentSucceeded {
                     id: intent.id.to_string(),
                     payment_method_id: method.id.to_string(),

--- a/crates/billing/src/subscription/update_stripe_setup_intent_status.rs
+++ b/crates/billing/src/subscription/update_stripe_setup_intent_status.rs
@@ -1,5 +1,5 @@
 use crate::types::subscription::StripeSetupIntentSucceeded;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use stripe_shared::{SetupIntent, SetupIntentStatus};
 use stripe_types::Expandable;
 
@@ -17,7 +17,7 @@ impl<E: Executor> super::Module<E> {
             (intent.status, intent.payment_method)
         {
             subscription
-                .aggregator()?
+                .write()?
                 .event(&StripeSetupIntentSucceeded {
                     id: intent.id.to_string(),
                     name: method.billing_details.name.to_owned(),

--- a/crates/billing/src/types/invoice.rs
+++ b/crates/billing/src/types/invoice.rs
@@ -10,7 +10,7 @@ pub struct InvoiceAddress {
     pub address: Address,
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Invoice {
     Created {
         key: String,

--- a/crates/billing/src/types/subscription.rs
+++ b/crates/billing/src/types/subscription.rs
@@ -203,7 +203,7 @@ fn country_name(code: &str) -> &'static str {
     }
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Subscription {
     LifePremiumToggled {
         expire_at: u64,

--- a/crates/core/src/contact/query/admin.rs
+++ b/crates/core/src/contact/query/admin.rs
@@ -232,7 +232,7 @@ async fn handle_form_submmited(
     event: Event<FormSubmitted>,
     data: &mut AdminView,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.email = event.data.email.to_owned();
     data.status.0 = Status::Unread;
     data.subject.0 = event.data.subject.to_owned();

--- a/crates/core/src/contact/root/mark_read_and_reply.rs
+++ b/crates/core/src/contact/root/mark_read_and_reply.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::contact::{MarkedReadAndReply, Status};
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -16,7 +16,7 @@ impl<E: Executor + Clone> super::Module<E> {
         }
 
         contact
-            .aggregator()?
+            .write()?
             .event(&MarkedReadAndReply)
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/core/src/contact/root/mod.rs
+++ b/crates/core/src/contact/root/mod.rs
@@ -1,5 +1,5 @@
 use bitcode::{Decode, Encode};
-use evento::{Executor, Projection, ProjectionAggregator, metadata::Event};
+use evento::{Executor, Projection, ProjectionAggregate, metadata::Event};
 use imkitchen_types::contact::{
     self, FormSubmitted, MarkedReadAndReply, Reopened, Resolved, Status,
 };
@@ -39,8 +39,8 @@ pub struct Contact {
     pub status: Status,
 }
 
-impl ProjectionAggregator for Contact {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for Contact {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
@@ -51,7 +51,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, Contact> {
         .handler(handle_reopened())
         .handler(handle_resolved())
         .handler(handle_marked_read_and_reply())
-        .safety_check()
+        .strict()
 }
 
 #[evento::handler]
@@ -59,7 +59,7 @@ async fn handle_form_submitted(
     event: Event<FormSubmitted>,
     row: &mut Contact,
 ) -> anyhow::Result<()> {
-    row.id = event.aggregator_id.to_owned();
+    row.id = event.aggregate_id.to_owned();
     row.status = Status::Unread;
 
     Ok(())

--- a/crates/core/src/contact/root/reopen.rs
+++ b/crates/core/src/contact/root/reopen.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::contact::{Reopened, Status};
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -16,7 +16,7 @@ impl<E: Executor + Clone> super::Module<E> {
         }
 
         contact
-            .aggregator()?
+            .write()?
             .event(&Reopened)
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/core/src/contact/root/resolve.rs
+++ b/crates/core/src/contact/root/resolve.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::contact::{Resolved, Status};
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -16,7 +16,7 @@ impl<E: Executor + Clone> super::Module<E> {
         }
 
         contact
-            .aggregator()?
+            .write()?
             .event(&Resolved)
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/core/src/mealplan/query/slot.rs
+++ b/crates/core/src/mealplan/query/slot.rs
@@ -284,7 +284,7 @@ async fn handle_days_generated<E: Executor>(
             MealPlanRecipe::AdvancePrep,
         ])
         .from(MealPlanRecipe::Table)
-        .and_where(Expr::col(MealPlanRecipe::UserId).eq(&event.aggregator_id))
+        .and_where(Expr::col(MealPlanRecipe::UserId).eq(&event.aggregate_id))
         .and_where(Expr::col(MealPlanRecipe::Id).is_in(recipe_ids))
         .to_owned();
 
@@ -310,7 +310,7 @@ async fn handle_days_generated<E: Executor>(
         ])
         .to_owned();
     let mut has_values = false;
-    let user_id = event.aggregator_id.to_owned();
+    let user_id = event.aggregate_id.to_owned();
     let timestamp = event.timestamp;
     for slot in event.data.slots {
         let Some(main_course): Option<DaySlotRecipe> = recipes
@@ -408,7 +408,7 @@ async fn handle_slot_recipe_status_changed<E: Executor>(
     event: Event<SlotRecipeStatusChanged>,
 ) -> anyhow::Result<()> {
     let pool = context.extract::<sqlx::SqlitePool>();
-    let user_id = event.aggregator_id.to_owned();
+    let user_id = event.aggregate_id.to_owned();
 
     let (sql, values) = Query::select()
         .columns([

--- a/crates/core/src/mealplan/root/change_slot_recipe_status.rs
+++ b/crates/core/src/mealplan/root/change_slot_recipe_status.rs
@@ -1,6 +1,6 @@
 use evento::Executor;
 use evento::cursor::Args;
-use evento::{Aggregator, ReadAggregator};
+use evento::{Aggregate, EventFilter};
 use imkitchen_types::mealplan::{DaySlotStatus, MealPlan, SlotRecipeStatusChanged};
 
 pub struct ChangeSlotRecipeStatus {
@@ -18,8 +18,8 @@ impl<E: Executor> super::Module<E> {
         let last_event = self
             .executor
             .read(
-                Some(vec![ReadAggregator::id(
-                    MealPlan::aggregator_type(),
+                Some(vec![EventFilter::by_id(
+                    MealPlan::aggregate_type(),
                     &input.user_id,
                 )]),
                 None,
@@ -31,7 +31,7 @@ impl<E: Executor> super::Module<E> {
             crate::not_found!("mealplan not found");
         };
 
-        evento::aggregator(&input.user_id)
+        evento::append(&input.user_id)
             .event(&SlotRecipeStatusChanged {
                 date: input.date,
                 recipe_id: input.recipe_id,

--- a/crates/core/src/mealplan/root/generate.rs
+++ b/crates/core/src/mealplan/root/generate.rs
@@ -1,6 +1,6 @@
 use evento::Executor;
 use evento::cursor::Args;
-use evento::{Aggregator, ReadAggregator};
+use evento::{Aggregate, EventFilter};
 use imkitchen_db::mealplan_recipe::MealPlanRecipe;
 use imkitchen_types::mealplan::{DaysGenerated, MealPlan, Slot, SlotRecipe};
 use imkitchen_types::recipe::{DietaryRestriction, RecipeType};
@@ -64,8 +64,8 @@ impl<E: Executor> super::Module<E> {
         let last_event = self
             .executor
             .read(
-                Some(vec![ReadAggregator::id(
-                    MealPlan::aggregator_type(),
+                Some(vec![EventFilter::by_id(
+                    MealPlan::aggregate_type(),
                     &input.user_id,
                 )]),
                 None,
@@ -80,7 +80,7 @@ impl<E: Executor> super::Module<E> {
             .unwrap_or_default();
 
         let mut main_course_recipes = main_course_recipes.iter().cycle().take(input.days as usize);
-        let mut builder = evento::aggregator(&input.user_id)
+        let mut builder = evento::append(&input.user_id)
             .original_version(version)
             .requested_by(&input.user_id)
             .to_owned();

--- a/crates/core/src/mealplan/root/mod.rs
+++ b/crates/core/src/mealplan/root/mod.rs
@@ -3,7 +3,7 @@ mod generate;
 
 use bitcode::{Decode, Encode};
 use evento::{
-    Executor, Projection, ProjectionAggregator,
+    Executor, Projection, ProjectionAggregate,
     metadata::Event,
     subscription::{Context, SubscriptionBuilder},
 };
@@ -49,8 +49,8 @@ pub struct MealPlan {
     pub generated_at: u64,
 }
 
-impl ProjectionAggregator for MealPlan {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for MealPlan {
+    fn aggregate_id(&self) -> String {
         self.user_id.to_owned()
     }
 }
@@ -59,7 +59,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, MealPlan> {
     Projection::new::<mealplan::MealPlan>()
         .handler(handle_generated())
         .skip::<SlotRecipeStatusChanged>()
-        .safety_check()
+        .strict()
 }
 
 #[evento::handler]
@@ -104,7 +104,7 @@ async fn handle_recipe_created<E: Executor>(
             MealPlanRecipe::DietaryRestrictions,
         ])
         .values_panic([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.metadata.requested_by()?.into(),
             RecipeType::default().to_string().into(),
             event.data.name.into(),
@@ -146,7 +146,7 @@ async fn handle_recipe_imported<E: Executor>(
             MealPlanRecipe::AcceptsAccompaniment,
         ])
         .values_panic([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.metadata.requested_by()?.into(),
             event.data.recipe_type.to_string().into(),
             event.data.name.into(),
@@ -173,7 +173,7 @@ async fn handle_recipe_type_changed<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     update_col(
         &pool,
-        &event.aggregator_id,
+        &event.aggregate_id,
         MealPlanRecipe::RecipeType,
         event.data.recipe_type.to_string(),
     )
@@ -190,7 +190,7 @@ async fn handle_recipe_deleted<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     let statement = Query::delete()
         .from_table(MealPlanRecipe::Table)
-        .and_where(Expr::col(MealPlanRecipe::Id).eq(&event.aggregator_id))
+        .and_where(Expr::col(MealPlanRecipe::Id).eq(&event.aggregate_id))
         .to_owned();
 
     let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
@@ -212,7 +212,7 @@ async fn handle_recipe_basic_information_changed<E: Executor>(
         .value(MealPlanRecipe::Name, &event.data.name)
         .value(MealPlanRecipe::PrepTime, event.data.prep_time)
         .value(MealPlanRecipe::CookTime, event.data.cook_time)
-        .and_where(Expr::col(MealPlanRecipe::Id).eq(&event.aggregator_id))
+        .and_where(Expr::col(MealPlanRecipe::Id).eq(&event.aggregate_id))
         .to_owned();
 
     let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
@@ -238,7 +238,7 @@ async fn handle_recipe_dietary_restrictions_changed<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     update_col(
         &pool,
-        &event.aggregator_id,
+        &event.aggregate_id,
         MealPlanRecipe::DietaryRestrictions,
         serde_json::Value::Array(dietary_restrictions),
     )
@@ -255,7 +255,7 @@ async fn handle_recipe_main_course_changed<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     update_col(
         &pool,
-        &event.aggregator_id,
+        &event.aggregate_id,
         MealPlanRecipe::AcceptsAccompaniment,
         event.data.accepts_accompaniment,
     )
@@ -272,7 +272,7 @@ async fn handle_recipe_advance_prep_changed<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     update_col(
         &pool,
-        &event.aggregator_id,
+        &event.aggregate_id,
         MealPlanRecipe::AdvancePrep,
         &event.data.advance_prep,
     )

--- a/crates/core/src/recipe/favorite/mod.rs
+++ b/crates/core/src/recipe/favorite/mod.rs
@@ -2,7 +2,7 @@ mod save;
 mod unsave;
 
 use bitcode::{Decode, Encode};
-use evento::{Executor, Projection, ProjectionAggregator, metadata::Event};
+use evento::{Executor, Projection, ProjectionAggregate, metadata::Event};
 use imkitchen_types::favorite::{self};
 use std::ops::Deref;
 
@@ -50,18 +50,18 @@ pub fn create_projection<E: Executor>() -> Projection<E, Favorite> {
     Projection::new::<favorite::Favorite>()
         .handler(handle_saved())
         .handler(handle_unsaved())
-        .safety_check()
+        .strict()
 }
 
-impl ProjectionAggregator for Favorite {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for Favorite {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
 
 #[evento::handler]
 async fn handle_saved(event: Event<favorite::Saved>, data: &mut Favorite) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.saved = true;
 
     Ok(())
@@ -72,7 +72,7 @@ async fn handle_unsaved(
     event: Event<favorite::Unsaved>,
     data: &mut Favorite,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.saved = false;
 
     Ok(())

--- a/crates/core/src/recipe/favorite/save.rs
+++ b/crates/core/src/recipe/favorite/save.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::favorite::Saved;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -14,7 +14,7 @@ impl<E: Executor + Clone> super::Module<E> {
 
         if !favorite.saved {
             favorite
-                .aggregator()?
+                .write()?
                 .event(&Saved {
                     recipe_id: id,
                     recipe_owner: owner_id.into(),

--- a/crates/core/src/recipe/favorite/unsave.rs
+++ b/crates/core/src/recipe/favorite/unsave.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::favorite::Unsaved;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -12,7 +12,7 @@ impl<E: Executor + Clone> super::Module<E> {
         let favorite = self.load(&id, &user_id).await?;
         if favorite.saved {
             favorite
-                .aggregator()?
+                .write()?
                 .event(&Unsaved { recipe_id: id })
                 .requested_by(user_id)
                 .commit(&self.executor)

--- a/crates/core/src/recipe/query/thumbnail.rs
+++ b/crates/core/src/recipe/query/thumbnail.rs
@@ -64,7 +64,7 @@ async fn handle_resized<E: Executor>(
             RecipeThumbnail::Data,
         ])
         .values_panic([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.data.device.to_owned().into(),
             event.data.data.into(),
         ])
@@ -93,7 +93,7 @@ async fn handle_deleted<E: Executor>(
 
     let statement = Query::delete()
         .from_table(RecipeThumbnail::Table)
-        .and_where(Expr::col(RecipeThumbnail::Id).eq(&event.aggregator_id))
+        .and_where(Expr::col(RecipeThumbnail::Id).eq(&event.aggregate_id))
         .to_owned();
 
     let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -598,7 +598,7 @@ async fn handle_created(event: Event<Created>, data: &mut UserView) -> anyhow::R
     data.owner_id = event.metadata.requested_by()?;
     data.owner_name = event.data.owner_name.to_owned();
     data.created_at = event.timestamp;
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.name = event.data.name;
     data.household_size = 4;
 
@@ -610,7 +610,7 @@ async fn handle_imported(event: Event<Imported>, data: &mut UserView) -> anyhow:
     data.created_at = event.timestamp;
     data.owner_id = event.metadata.requested_by()?;
     data.owner_name = event.data.owner_name.to_owned();
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.name = event.data.name;
     data.origin = event.data.origin;
     data.description = event.data.description;

--- a/crates/core/src/recipe/query/user_fts.rs
+++ b/crates/core/src/recipe/query/user_fts.rs
@@ -35,7 +35,7 @@ async fn handle_created<E: Executor>(
             RecipeUserFts::Ingredients,
         ])
         .values([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.data.name.into(),
             "".into(),
             "".into(),
@@ -72,7 +72,7 @@ async fn handle_imported<E: Executor>(
             RecipeUserFts::Ingredients,
         ])
         .values([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.data.name.into(),
             event.data.description.into(),
             ingredients.into(),
@@ -96,7 +96,7 @@ async fn handle_basic_information_changed<E: Executor>(
         .table(RecipeUserFts::Table)
         .and_where(Expr::cust_with_values(
             "recipe_user_fts = ?",
-            [event.aggregator_id.to_owned()],
+            [event.aggregate_id.to_owned()],
         ))
         .values([
             (RecipeUserFts::Name, event.data.name.into()),
@@ -130,7 +130,7 @@ async fn handle_ingredients_changed<E: Executor>(
         .table(RecipeUserFts::Table)
         .and_where(Expr::cust_with_values(
             "recipe_user_fts = ?",
-            [event.aggregator_id.to_owned()],
+            [event.aggregate_id.to_owned()],
         ))
         .value(RecipeUserFts::Name, ingredients)
         .build_sqlx(SqliteQueryBuilder);
@@ -151,7 +151,7 @@ async fn handle_deleted<E: Executor>(
         .from_table(RecipeUserFts::Table)
         .and_where(Expr::cust_with_values(
             "recipe_user_fts = ?",
-            [event.aggregator_id.to_owned()],
+            [event.aggregate_id.to_owned()],
         ))
         .build_sqlx(SqliteQueryBuilder);
 

--- a/crates/core/src/recipe/root/delete.rs
+++ b/crates/core/src/recipe/root/delete.rs
@@ -1,4 +1,4 @@
-use evento::{Aggregator, Executor, ProjectionAggregator};
+use evento::{Aggregate, Executor, ProjectionAggregate};
 use imkitchen_types::recipe::{self, Deleted};
 
 impl<E: Executor> super::Module<E> {
@@ -18,14 +18,14 @@ impl<E: Executor> super::Module<E> {
         }
 
         recipe
-            .aggregator()?
+            .write()?
             .event(&Deleted)
             .requested_by(request_by)
             .commit(&self.executor)
             .await?;
 
         self.executor
-            .delete_snapshot(recipe::Recipe::aggregator_type().to_owned(), id)
+            .delete_snapshot(recipe::Recipe::aggregate_type().to_owned(), id)
             .await?;
 
         Ok(())

--- a/crates/core/src/recipe/root/make_all_private.rs
+++ b/crates/core/src/recipe/root/make_all_private.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe_share::AllMadePrivate;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -8,7 +8,7 @@ impl<E: Executor + Clone> super::Module<E> {
         let share = self.load_share(&request_by).await?;
 
         share
-            .aggregator()?
+            .write()?
             .event(&AllMadePrivate)
             .requested_by(&request_by)
             .commit(&self.executor)

--- a/crates/core/src/recipe/root/make_private.rs
+++ b/crates/core/src/recipe/root/make_private.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe::MadePrivate;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -18,7 +18,7 @@ impl<E: Executor + Clone> super::Module<E> {
 
         if recipe.is_shared {
             recipe
-                .aggregator()?
+                .write()?
                 .event(&MadePrivate)
                 .requested_by(request_by)
                 .commit(&self.executor)

--- a/crates/core/src/recipe/root/mod.rs
+++ b/crates/core/src/recipe/root/mod.rs
@@ -1,6 +1,6 @@
 use bitcode::{Decode, Encode};
 use evento::{
-    AggregatorExecutor, Executor, Projection, ProjectionAggregator,
+    AggregateExt, Executor, Projection, ProjectionAggregate,
     metadata::Event,
     subscription::{Context, SubscriptionBuilder},
 };
@@ -94,11 +94,11 @@ pub fn create_share_projection<E: Executor>() -> Projection<E, RecipeShareState>
     Projection::new::<recipe_share::RecipeShare>()
         .handler(handle_all_shared_to_community())
         .handler(handle_all_made_private())
-        .safety_check()
+        .strict()
 }
 
-impl ProjectionAggregator for RecipeShareState {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for RecipeShareState {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
@@ -108,7 +108,7 @@ async fn handle_all_shared_to_community(
     event: Event<AllSharedToCommunity>,
     data: &mut RecipeShareState,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     Ok(())
 }
 
@@ -117,7 +117,7 @@ async fn handle_all_made_private(
     event: Event<AllMadePrivate>,
     data: &mut RecipeShareState,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     Ok(())
 }
 
@@ -139,18 +139,18 @@ pub fn create_projection<E: Executor>() -> Projection<E, Recipe> {
         .skip::<ThumbnailUploaded>()
         .skip::<ThumbnailResized>()
         .skip::<CuisineTypeChanged>()
-        .safety_check()
+        .strict()
 }
 
-impl ProjectionAggregator for Recipe {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for Recipe {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
 
 #[evento::handler]
 async fn handle_created(event: Event<Created>, data: &mut Recipe) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.owner_id = event.metadata.requested_by()?;
 
     Ok(())
@@ -158,7 +158,7 @@ async fn handle_created(event: Event<Created>, data: &mut Recipe) -> anyhow::Res
 
 #[evento::handler]
 async fn handle_imported(event: Event<Imported>, data: &mut Recipe) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.owner_id = event.metadata.requested_by()?;
     data.recipe_type = event.data.recipe_type;
 
@@ -358,7 +358,7 @@ async fn handle_thumbnail_uploaded<E: Executor>(
 ) -> anyhow::Result<()> {
     let original_version = context
         .executor
-        .original_version::<ThumbnailResized>(&event.aggregator_id)
+        .original_version::<ThumbnailResized>(&event.aggregate_id)
         .await?
         .expect("aggregator exist");
     let img = match image::load_from_memory(&event.data.data) {
@@ -369,7 +369,7 @@ async fn handle_thumbnail_uploaded<E: Executor>(
             return Ok(());
         }
     };
-    let mut builder = evento::aggregator(&event.aggregator_id)
+    let mut builder = evento::append(&event.aggregate_id)
         .original_version(original_version)
         .metadata_from(&event.metadata)
         .to_owned();

--- a/crates/core/src/recipe/root/share_all_to_community.rs
+++ b/crates/core/src/recipe/root/share_all_to_community.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe_share::AllSharedToCommunity;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -13,7 +13,7 @@ impl<E: Executor + Clone> super::Module<E> {
         let share = self.load_share(&request_by).await?;
 
         share
-            .aggregator()?
+            .write()?
             .event(&AllSharedToCommunity { owner_name })
             .requested_by(&request_by)
             .commit(&self.executor)

--- a/crates/core/src/recipe/root/share_to_community.rs
+++ b/crates/core/src/recipe/root/share_to_community.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe::SharedToCommunity;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -19,7 +19,7 @@ impl<E: Executor + Clone> super::Module<E> {
 
         if !recipe.is_shared {
             recipe
-                .aggregator()?
+                .write()?
                 .event(&SharedToCommunity {
                     owner_name: owner_name.into(),
                 })

--- a/crates/core/src/recipe/root/update.rs
+++ b/crates/core/src/recipe/root/update.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use sha3::{Digest, Sha3_224};
 use validator::Validate;
 
@@ -47,7 +47,7 @@ impl<E: Executor + Clone> super::Module<E> {
             crate::forbidden!("not owner of recipe");
         }
 
-        let mut builder = recipe.aggregator()?.requested_by(request_by).to_owned();
+        let mut builder = recipe.write()?.requested_by(request_by).to_owned();
         let mut has_data = false;
 
         if recipe.recipe_type != input.recipe_type {

--- a/crates/core/src/recipe/root/upload_thumbnail.rs
+++ b/crates/core/src/recipe/root/upload_thumbnail.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe::ThumbnailUploaded;
 
 impl<E: Executor + Clone> super::Module<E> {
@@ -22,7 +22,7 @@ impl<E: Executor + Clone> super::Module<E> {
         };
 
         recipe
-            .aggregator()?
+            .write()?
             .event(&ThumbnailUploaded { data })
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/core/src/recipe/saga/mod.rs
+++ b/crates/core/src/recipe/saga/mod.rs
@@ -16,7 +16,7 @@
 //! truncate). That is what keeps the historical backfill race-free.
 
 use evento::{
-    Executor, ProjectionAggregator,
+    Executor, ProjectionAggregate,
     metadata::Event,
     subscription::{Context, SubscriptionBuilder},
 };
@@ -83,7 +83,7 @@ async fn handle_created<E: Executor>(
     let (_, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
     index_owner(
         &write_db,
-        &event.aggregator_id,
+        &event.aggregate_id,
         &event.metadata.requested_by()?,
     )
     .await
@@ -97,7 +97,7 @@ async fn handle_imported<E: Executor>(
     let (_, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
     index_owner(
         &write_db,
-        &event.aggregator_id,
+        &event.aggregate_id,
         &event.metadata.requested_by()?,
     )
     .await
@@ -111,7 +111,7 @@ async fn handle_deleted<E: Executor>(
     let (_, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
     let (sql, values) = Query::delete()
         .from_table(RecipeOwner::Table)
-        .and_where(Expr::col(RecipeOwner::RecipeId).eq(&event.aggregator_id))
+        .and_where(Expr::col(RecipeOwner::RecipeId).eq(&event.aggregate_id))
         .build_sqlx(SqliteQueryBuilder);
 
     sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
@@ -145,7 +145,7 @@ async fn handle_all_shared_to_community<E: Executor>(
         }
 
         recipe
-            .aggregator()?
+            .write()?
             .event(&SharedToCommunity {
                 owner_name: event.data.owner_name.to_owned(),
             })
@@ -179,7 +179,7 @@ async fn handle_all_made_private<E: Executor>(
         }
 
         recipe
-            .aggregator()?
+            .write()?
             .event(&MadePrivate)
             .requested_by(owner_id.as_str())
             .commit(context.executor)

--- a/crates/core/src/shopping/query/list.rs
+++ b/crates/core/src/shopping/query/list.rs
@@ -67,7 +67,7 @@ async fn handle_generated<E: Executor>(
             ShoppingList::GeneratedAt,
         ])
         .values_panic([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             ingredients.into(),
             event.data.from_date.into(),
             (event.data.days as i32).into(),

--- a/crates/core/src/shopping/root/generate.rs
+++ b/crates/core/src/shopping/root/generate.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_db::shopping_recipe::ShoppingRecipe;
 use imkitchen_db::shopping_slot::ShoppingSlot;
 use imkitchen_types::{recipe::Ingredient, shopping::Generated};
@@ -61,7 +61,7 @@ impl<E: Executor> super::Module<E> {
         }
 
         shopping
-            .aggregator()?
+            .write()?
             .event(&Generated {
                 ingredients: ingredients.values().cloned().collect(),
                 from_date: input.date,

--- a/crates/core/src/shopping/root/mod.rs
+++ b/crates/core/src/shopping/root/mod.rs
@@ -5,7 +5,7 @@ use bitcode::{Decode, Encode};
 pub use generate::Generate;
 pub use toogle::*;
 
-use evento::{Executor, Projection, ProjectionAggregator, metadata::Event};
+use evento::{Executor, Projection, ProjectionAggregate, metadata::Event};
 use imkitchen_types::shopping::{self, Checked, Generated, Unchecked};
 use std::{collections::HashSet, ops::Deref};
 
@@ -45,8 +45,8 @@ pub struct Shopping {
     pub generated_at: u64,
 }
 
-impl ProjectionAggregator for Shopping {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for Shopping {
+    fn aggregate_id(&self) -> String {
         self.user_id.to_owned()
     }
 }
@@ -56,7 +56,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, Shopping> {
         .handler(handle_checked())
         .handler(handle_generated())
         .handler(handle_unchecked())
-        .safety_check()
+        .strict()
 }
 
 #[evento::handler]

--- a/crates/core/src/shopping/root/toogle.rs
+++ b/crates/core/src/shopping/root/toogle.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::shopping::{Checked, Unchecked};
 
 pub struct ToggleInput {
@@ -24,7 +24,7 @@ impl<E: Executor> super::Module<E> {
 
         if checked {
             shopping
-                .aggregator()?
+                .write()?
                 .event(&Unchecked {
                     ingredient: input.name,
                 })
@@ -33,7 +33,7 @@ impl<E: Executor> super::Module<E> {
                 .await?;
         } else {
             shopping
-                .aggregator()?
+                .write()?
                 .event(&Checked {
                     ingredient: input.name,
                 })

--- a/crates/core/src/shopping/subscription.rs
+++ b/crates/core/src/shopping/subscription.rs
@@ -89,7 +89,7 @@ async fn handle_recipe_created<E: Executor>(
             ShoppingRecipe::Ingredients,
         ])
         .values([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.metadata.requested_by()?.into(),
             ingredients.into(),
         ])?
@@ -118,7 +118,7 @@ async fn handle_recipe_imported<E: Executor>(
             ShoppingRecipe::Ingredients,
         ])
         .values([
-            event.aggregator_id.to_owned().into(),
+            event.aggregate_id.to_owned().into(),
             event.metadata.requested_by()?.into(),
             ingredients.into(),
         ])?
@@ -139,7 +139,7 @@ async fn handle_recipe_deleted<E: Executor>(
     let pool = context.extract::<sqlx::SqlitePool>();
     let statement = Query::delete()
         .from_table(ShoppingRecipe::Table)
-        .and_where(Expr::col(ShoppingRecipe::Id).eq(&event.aggregator_id))
+        .and_where(Expr::col(ShoppingRecipe::Id).eq(&event.aggregate_id))
         .to_owned();
 
     let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
@@ -160,7 +160,7 @@ async fn handle_recipe_ingredients_changed<E: Executor>(
 
     update_col(
         &pool,
-        &event.aggregator_id,
+        &event.aggregate_id,
         ShoppingRecipe::Ingredients,
         ingredients,
     )

--- a/crates/core/tests/contact/safety_check.rs
+++ b/crates/core/tests/contact/safety_check.rs
@@ -16,7 +16,7 @@ async fn test_mark_read_and_reply() -> anyhow::Result<()> {
 
     imkitchen_core::contact::global_stat::subscription()
         .data(state.write_db.clone())
-        .unretry_execute(&state.executor)
+        .no_retry().run_once(&state.executor)
         .await?;
 
     Ok(())

--- a/crates/core/tests/mealplan/generate.rs
+++ b/crates/core/tests/mealplan/generate.rs
@@ -28,7 +28,7 @@ async fn test_random() -> anyhow::Result<()> {
 
     imkitchen_core::mealplan::subscription()
         .data(state.write_db.clone())
-        .unretry_execute(&state.executor)
+        .no_retry().run_once(&state.executor)
         .await?;
 
     cmd.generate(imkitchen_core::mealplan::Generate {

--- a/crates/identity/src/meal_preferences/mod.rs
+++ b/crates/identity/src/meal_preferences/mod.rs
@@ -50,18 +50,18 @@ pub struct MealPreferences {
 fn create_projection<E: Executor>() -> Projection<E, MealPreferences> {
     Projection::new::<meal_preferences::MealPreferences>()
         .handler(handle_updated())
-        .safety_check()
+        .strict()
 }
 
-impl evento::ProjectionAggregator for MealPreferences {
-    fn aggregator_id(&self) -> String {
+impl evento::ProjectionAggregate for MealPreferences {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
 
 #[evento::handler]
 async fn handle_updated(event: Event<Changed>, data: &mut MealPreferences) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.household_size = event.data.household_size;
     data.dietary_restrictions = event.data.dietary_restrictions;
     data.cuisine_variety_weight = event.data.cuisine_variety_weight;

--- a/crates/identity/src/meal_preferences/update.rs
+++ b/crates/identity/src/meal_preferences/update.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::meal_preferences::Changed;
 use imkitchen_types::recipe::DietaryRestriction;
 use validator::Validate;
@@ -24,7 +24,7 @@ impl<E: Executor> super::Module<E> {
         let preferences = self.load(&id).await?;
 
         preferences
-            .aggregator()?
+            .write()?
             .event(&Changed {
                 dietary_restrictions: input.dietary_restrictions,
                 household_size: input.household_size,

--- a/crates/identity/src/password/mod.rs
+++ b/crates/identity/src/password/mod.rs
@@ -40,11 +40,11 @@ fn create_projection<E: Executor>() -> Projection<E, Password> {
     Projection::new::<password::Password>()
         .handler(handle_reset_requested())
         .handler(handle_reset_completed())
-        .safety_check()
+        .strict()
 }
 
-impl evento::ProjectionAggregator for Password {
-    fn aggregator_id(&self) -> String {
+impl evento::ProjectionAggregate for Password {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
@@ -54,7 +54,7 @@ async fn handle_reset_requested(
     event: Event<ResetRequested>,
     data: &mut Password,
 ) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.user_id = event.data.user_id.to_owned();
     data.completed = false;
     data.expire_at = (OffsetDateTime::from_unix_timestamp(event.timestamp.try_into()?)?

--- a/crates/identity/src/password/reset.rs
+++ b/crates/identity/src/password/reset.rs
@@ -3,7 +3,7 @@ use argon2::{
     Argon2, PasswordHasher,
     password_hash::{SaltString, rand_core::OsRng},
 };
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use time::OffsetDateTime;
 use validator::Validate;
 
@@ -52,7 +52,7 @@ impl<E: Executor> super::Module<E> {
         .await?;
 
         password
-            .aggregator()?
+            .write()?
             .event(&ResetCompleted)
             .requested_by(&password.user_id)
             .commit(&self.executor)

--- a/crates/identity/src/query/admin.rs
+++ b/crates/identity/src/query/admin.rs
@@ -36,7 +36,7 @@ pub(crate) async fn load<E: Executor>(
     create_projection()
         .data((read_db.clone(), write_db.clone()))
         .load(&id)
-        .aggregator::<Subscription>(id)
+        .aggregate::<Subscription>(id)
         .execute(executor)
         .await
 }
@@ -321,7 +321,7 @@ impl<E: Executor> Snapshot<E> for AdminView {
 
 #[evento::handler]
 async fn handle_registered(event: Event<Registered>, data: &mut AdminView) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.email = event.data.email.to_owned();
     data.role.0 = Role::User;
     data.state.0 = State::Active;

--- a/crates/identity/src/query/login.rs
+++ b/crates/identity/src/query/login.rs
@@ -24,7 +24,7 @@ impl<E: Executor> crate::Module<E> {
         create_projection()
             .data((self.read_db.clone(), self.write_db.clone()))
             .load(&id)
-            .aggregator::<Subscription>(id)
+            .aggregate::<Subscription>(id)
             .execute(&self.executor)
             .await
     }
@@ -179,7 +179,7 @@ impl<E: Executor> Snapshot<E> for LoginView {
 
 #[evento::handler]
 async fn handle_registered(event: Event<Registered>, data: &mut LoginView) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.email = event.data.email.to_owned();
 
     Ok(())
@@ -201,7 +201,7 @@ async fn handle_username_changed(
 
 #[evento::handler]
 async fn handle_logged_in(event: Event<LoggedIn>, data: &mut LoginView) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.logins
         .retain(|r| r.user_agent != event.data.user_agent);
     data.logins.push(Login {

--- a/crates/identity/src/root/activate.rs
+++ b/crates/identity/src/root/activate.rs
@@ -1,5 +1,5 @@
 use crate::types::user::{Activated, State};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn activate(
@@ -15,7 +15,7 @@ impl<E: Executor> super::Module<E> {
             return Ok(());
         }
 
-        user.aggregator()?
+        user.write()?
             .event(&Activated)
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/identity/src/root/change_role.rs
+++ b/crates/identity/src/root/change_role.rs
@@ -1,5 +1,5 @@
 use crate::types::user::{Role, RoleChanged};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn change_role(
@@ -16,7 +16,7 @@ impl<E: Executor> super::Module<E> {
             return Ok(());
         }
 
-        user.aggregator()?
+        user.write()?
             .event(&RoleChanged { role })
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/identity/src/root/login.rs
+++ b/crates/identity/src/root/login.rs
@@ -1,6 +1,6 @@
 use crate::types::user::{LoggedIn, Logout, State};
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use ulid::Ulid;
 use validator::Validate;
 
@@ -47,7 +47,7 @@ impl<E: Executor> super::Module<E> {
 
         let access_id = Ulid::new().to_string();
 
-        user.aggregator()?
+        user.write()?
             .event(&LoggedIn {
                 lang: input.lang,
                 timezone: input.timezone,
@@ -69,7 +69,7 @@ impl<E: Executor> super::Module<E> {
             imkitchen_core::not_found!("user in logout");
         };
 
-        user.aggregator()?
+        user.write()?
             .event(&Logout {
                 access_id: access_id.to_owned(),
             })

--- a/crates/identity/src/root/made_admin.rs
+++ b/crates/identity/src/root/made_admin.rs
@@ -1,5 +1,5 @@
 use crate::types::user::{MadeAdmin, Role};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn made_admin(&self, id: impl Into<String>) -> imkitchen_core::Result<()> {
@@ -11,7 +11,7 @@ impl<E: Executor> super::Module<E> {
             return Ok(());
         }
 
-        user.aggregator()?
+        user.write()?
             .event(&MadeAdmin)
             .commit(&self.executor)
             .await?;

--- a/crates/identity/src/root/mod.rs
+++ b/crates/identity/src/root/mod.rs
@@ -3,7 +3,7 @@ use crate::types::user::{
     UsernameChanged,
 };
 use bitcode::{Decode, Encode};
-use evento::{Executor, Projection, ProjectionAggregator, metadata::Event};
+use evento::{Executor, Projection, ProjectionAggregate, metadata::Event};
 use std::ops::Deref;
 
 use crate::repository::{self};
@@ -81,18 +81,18 @@ pub fn create_projection<E: Executor>() -> Projection<E, User> {
         .skip::<LoggedIn>()
         .skip::<Logout>()
         .skip::<UsernameChanged>()
-        .safety_check()
+        .strict()
 }
 
-impl ProjectionAggregator for User {
-    fn aggregator_id(&self) -> String {
+impl ProjectionAggregate for User {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
 
 #[evento::handler]
 async fn handle_registered(event: Event<Registered>, data: &mut User) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.state = State::Active;
     data.role = Role::User;
 

--- a/crates/identity/src/root/set_username.rs
+++ b/crates/identity/src/root/set_username.rs
@@ -1,5 +1,5 @@
 use crate::types::user::UsernameChanged;
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use regex::Regex;
 use std::sync::LazyLock;
 use validator::Validate;
@@ -53,7 +53,7 @@ impl<E: Executor> super::Module<E> {
             imkitchen_core::server!("user in set_username");
         };
 
-        user.aggregator()?
+        user.write()?
             .event(&UsernameChanged {
                 value: input.username,
             })

--- a/crates/identity/src/root/suspend.rs
+++ b/crates/identity/src/root/suspend.rs
@@ -1,5 +1,5 @@
 use crate::types::user::{State, Suspended};
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 
 impl<E: Executor> super::Module<E> {
     pub async fn suspend(
@@ -15,7 +15,7 @@ impl<E: Executor> super::Module<E> {
             return Ok(());
         }
 
-        user.aggregator()?
+        user.write()?
             .event(&Suspended)
             .requested_by(request_by)
             .commit(&self.executor)

--- a/crates/identity/src/types/password.rs
+++ b/crates/identity/src/types/password.rs
@@ -1,4 +1,4 @@
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Password {
     ResetRequested {
         user_id: String,

--- a/crates/identity/src/types/user.rs
+++ b/crates/identity/src/types/user.rs
@@ -41,7 +41,7 @@ pub enum State {
     Suspended,
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum User {
     Registered {
         email: String,

--- a/crates/identity/src/user_profile/mod.rs
+++ b/crates/identity/src/user_profile/mod.rs
@@ -44,18 +44,18 @@ pub struct UserProfile {
 fn create_projection<E: Executor>() -> Projection<E, UserProfile> {
     Projection::new::<user_profile::UserProfile>()
         .handler(handle_changed())
-        .safety_check()
+        .strict()
 }
 
-impl evento::ProjectionAggregator for UserProfile {
-    fn aggregator_id(&self) -> String {
+impl evento::ProjectionAggregate for UserProfile {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
 
 #[evento::handler]
 async fn handle_changed(event: Event<Changed>, data: &mut UserProfile) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.description = event.data.description;
 
     Ok(())

--- a/crates/identity/src/user_profile/update.rs
+++ b/crates/identity/src/user_profile/update.rs
@@ -1,4 +1,4 @@
-use evento::{Executor, ProjectionAggregator};
+use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::user_profile::Changed;
 use validator::Validate;
 
@@ -20,7 +20,7 @@ impl<E: Executor> super::Module<E> {
         let profile = self.load(&id).await?;
 
         profile
-            .aggregator()?
+            .write()?
             .event(&Changed {
                 description: input.description,
             })

--- a/crates/identity/tests/safety_check.rs
+++ b/crates/identity/tests/safety_check.rs
@@ -58,7 +58,8 @@ async fn test_safety_check() -> anyhow::Result<()> {
         .skip::<MadeAdmin>()
         .skip::<UsernameChanged>()
         .data(state.write_db.clone())
-        .no_retry().run_once(&state.executor)
+        .no_retry()
+        .run_once(&state.executor)
         .await?;
 
     Ok(())

--- a/crates/identity/tests/safety_check.rs
+++ b/crates/identity/tests/safety_check.rs
@@ -52,13 +52,13 @@ async fn test_safety_check() -> anyhow::Result<()> {
     cmd.logout(&id, access_id).await?;
 
     imkitchen_identity::global_stat::subscription()
-        .safety_check()
+        .strict()
         .skip::<LoggedIn>()
         .skip::<Logout>()
         .skip::<MadeAdmin>()
         .skip::<UsernameChanged>()
         .data(state.write_db.clone())
-        .unretry_execute(&state.executor)
+        .no_retry().run_once(&state.executor)
         .await?;
 
     Ok(())

--- a/crates/notification/src/billing.rs
+++ b/crates/notification/src/billing.rs
@@ -80,7 +80,7 @@ async fn handle_invoice_created<E: Executor>(
     let price = event.data.details.price + event.data.details.tax;
     let amount = format!("{}.{:02} EUR", price / 100, price % 100);
     let invoice_number = format!("{}-{:04}", event.data.key, event.data.number);
-    let invoice_url = format!("{}/invoices/{}", service.app_url, event.aggregator_id);
+    let invoice_url = format!("{}/invoices/{}", service.app_url, event.aggregate_id);
 
     let html = template.to_string(InvoiceCreatedHtmlTemplate {
         email: email.to_owned(),
@@ -118,7 +118,7 @@ async fn handle_subscription_cancelled<E: Executor>(
     let service = context.extract::<EmailService>();
     let year = OffsetDateTime::from_unix_timestamp(event.timestamp.try_into()?)?.year();
 
-    let user_id = event.aggregator_id.to_owned();
+    let user_id = event.aggregate_id.to_owned();
     let (read_db, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
     let recipient = match recipient::load(context.executor, &read_db, &write_db, &user_id).await? {
         Some(r) => r,

--- a/crates/notification/src/recipient.rs
+++ b/crates/notification/src/recipient.rs
@@ -39,8 +39,8 @@ pub fn create_projection<E: Executor>() -> Projection<E, Recipient> {
         .handler(handle_logged_in())
 }
 
-impl evento::ProjectionAggregator for Recipient {
-    fn aggregator_id(&self) -> String {
+impl evento::ProjectionAggregate for Recipient {
+    fn aggregate_id(&self) -> String {
         self.id.to_owned()
     }
 }
@@ -130,7 +130,7 @@ impl<E: Executor> Snapshot<E> for Recipient {
 
 #[evento::handler]
 async fn handle_registered(event: Event<Registered>, data: &mut Recipient) -> anyhow::Result<()> {
-    data.id = event.aggregator_id.to_owned();
+    data.id = event.aggregate_id.to_owned();
     data.email = event.data.email.to_owned();
     data.lang = event.data.lang.to_owned();
     data.timezone = event.data.timezone.to_owned();

--- a/crates/notification/src/user.rs
+++ b/crates/notification/src/user.rs
@@ -44,7 +44,7 @@ async fn handle_reset_requested<E: Executor>(
 
     let reset_url = format!(
         "{}/reset-password/new/{}",
-        event.data.host, event.aggregator_id
+        event.data.host, event.aggregate_id
     );
 
     let html = template.to_string(ResetPasswordHtmlTemplate {

--- a/crates/types/src/contact.rs
+++ b/crates/types/src/contact.rs
@@ -46,7 +46,7 @@ pub enum Status {
     Resolved,
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Contact {
     FormSubmitted {
         name: String,

--- a/crates/types/src/favorite.rs
+++ b/crates/types/src/favorite.rs
@@ -1,4 +1,4 @@
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Favorite {
     Saved {
         recipe_id: String,

--- a/crates/types/src/meal_preferences.rs
+++ b/crates/types/src/meal_preferences.rs
@@ -1,6 +1,6 @@
 use crate::recipe::DietaryRestriction;
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum MealPreferences {
     Changed {
         household_size: u16,

--- a/crates/types/src/mealplan.rs
+++ b/crates/types/src/mealplan.rs
@@ -79,7 +79,7 @@ pub enum Status {
     Failed,
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum MealPlan {
     DaysGenerated {
         start: u64,

--- a/crates/types/src/recipe.rs
+++ b/crates/types/src/recipe.rs
@@ -200,7 +200,7 @@ impl DietaryRestriction {
     }
 }
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Recipe {
     Created {
         name: String,

--- a/crates/types/src/recipe_share.rs
+++ b/crates/types/src/recipe_share.rs
@@ -1,4 +1,4 @@
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum RecipeShare {
     AllSharedToCommunity { owner_name: String },
     AllMadePrivate,

--- a/crates/types/src/shopping.rs
+++ b/crates/types/src/shopping.rs
@@ -1,6 +1,6 @@
 use crate::recipe::Ingredient;
 
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum Shopping {
     Checked {
         ingredient: String,

--- a/crates/types/src/user_profile.rs
+++ b/crates/types/src/user_profile.rs
@@ -1,4 +1,4 @@
-#[evento::aggregator]
+#[evento::aggregate]
 pub enum UserProfile {
     Changed { description: String },
 }

--- a/web/shared/src/middleware/minify.rs
+++ b/web/shared/src/middleware/minify.rs
@@ -57,7 +57,7 @@ fn minify_js(source: &str) -> String {
     let source_type = SourceType::mjs();
 
     let parser_ret = Parser::new(&allocator, source, source_type).parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         return source.to_string();
     }
     let mut program = parser_ret.program;


### PR DESCRIPTION
## Summary

Routine dependency maintenance — four non-major upgrades, each verified to build, lint, and test cleanly.

| Crate | From | To | Source changes |
|-------|------|-----|----------------|
| `evento` | 2.0.0-alpha.21 (old API) | 2.0.0-alpha.21 (new API) | Full call-site migration to the redesigned API ([timayz/evento#204](https://github.com/timayz/evento/pull/204)) |
| `oxc` | 0.135.0 | 0.136.0 | `ParserReturn::errors` → `diagnostics` in the JS minifier |
| `tower-http` | 0.6 | 0.7 | None |
| `time` | `>=0.3.47, <0.3.48` | 0.3.49 | None — drops the cookie-build-error workaround pin |

### evento API renames

| Old | New |
|-----|-----|
| `#[evento::aggregator]` | `#[evento::aggregate]` |
| `Aggregator` / `AggregatorEvent` / `AggregatorExecutor` | `Aggregate` / `AggregateEvent` / `AggregateExt` |
| `event.aggregator_id` / `aggregator_type()` | `aggregate_id` / `aggregate_type()` |
| `ReadAggregator::{id,event,aggregator,new}` | `EventFilter::{by_id,by_event,by_type,exact}` |
| `AggregatorBuilder` | `WriteBuilder` |
| `ProjectionAggregator` | `ProjectionAggregate` |
| `evento::aggregator(id)` | `evento::append(id)` |
| `.aggregator()` (gateway/projection write) | `.write()` |
| `.aggregator::<T>(id)` (LoadBuilder) | `.aggregate::<T>(id)` |
| `.safety_check()` | `.strict()` |
| `.unretry_execute()` | `.no_retry().run_once()` |

No data migration — evento's SQL columns and on-disk keys are unchanged.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets` ✅ (no warnings)
- `cargo test --workspace` ✅ (all pass, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)