### PR TITLE
feat(admin): batch import recipes from ZIP with per-author Chef accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1408,6 +1411,17 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "derive_builder"
@@ -2727,15 +2741,23 @@ dependencies = [
  "askama",
  "axum",
  "evento",
+ "image",
  "imkitchen-billing",
  "imkitchen-core",
+ "imkitchen-db",
  "imkitchen-identity",
  "imkitchen-types",
  "imkitchen-web-shared",
  "serde",
+ "serde_json",
+ "sqlx",
  "strum 0.28.0",
+ "temp-dir",
  "time",
+ "tokio",
  "tracing",
+ "ulid",
+ "zip",
 ]
 
 [[package]]
@@ -7503,10 +7525,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ sha3 = "0.12"
 temp-dir = "0.2"
 rand = "0.10"
 tokio-cron-scheduler = "0.15"
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [package]
 name = "imkitchen"

--- a/crates/identity/src/root/mod.rs
+++ b/crates/identity/src/root/mod.rs
@@ -62,6 +62,38 @@ impl<E: Executor> Module<E> {
                 .map(|row| row.email),
         )
     }
+
+    /// Look up an account by email, returning its id, role and state. The role/state are read
+    /// from the event-sourced aggregate so they reflect the latest committed events even when
+    /// the read-model projection has not caught up yet.
+    pub async fn find_account(
+        &self,
+        email: impl Into<String>,
+    ) -> imkitchen_core::Result<Option<Account>> {
+        let Some(row) =
+            repository::find(&self.read_db, repository::FindType::Email(email.into())).await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(user) = self.load(&row.id).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(Account {
+            id: row.id,
+            role: user.role,
+            state: user.state,
+        }))
+    }
+}
+
+/// A minimal account view used when resolving an existing user by email.
+#[derive(Clone, Debug)]
+pub struct Account {
+    pub id: String,
+    pub role: Role,
+    pub state: State,
 }
 
 #[evento::projection(Encode, Decode)]

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -172,8 +172,16 @@ pub async fn serve(
         identity: imkitchen_identity::Module::new(state.clone()),
         billing: imkitchen_billing::Billing::new(state.clone()),
         core: imkitchen_core::Core::new(state.clone()),
+        import_jobs: Default::default(),
         inner: state,
     };
+
+    // The ZIP upload endpoint needs a much larger body than the global 1MB cap, so it is
+    // built separately and merged *after* the global limit layer with its own limit.
+    let admin_upload = imkitchen_web_admin::upload_routes()
+        .with_state(app_state.clone())
+        .layer(DefaultBodyLimit::disable())
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(50 * 1024 * 1024)); // 50MB
 
     let app = axum::Router::new()
         .route("/health", get(imkitchen_web_public::routes::health::health))
@@ -199,6 +207,7 @@ pub async fn serve(
         .with_state(app_state)
         .layer(DefaultBodyLimit::disable())
         .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024)) // 1MB
+        .merge(admin_upload)
         .layer(axum::middleware::from_fn(
             imkitchen_web_shared::middleware::cache_control_middleware,
         ))

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -181,7 +181,9 @@ pub async fn serve(
     let admin_upload = imkitchen_web_admin::upload_routes()
         .with_state(app_state.clone())
         .layer(DefaultBodyLimit::disable())
-        .layer(tower_http::limit::RequestBodyLimitLayer::new(50 * 1024 * 1024)); // 50MB
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(
+            50 * 1024 * 1024,
+        )); // 50MB
 
     let app = axum::Router::new()
         .route("/health", get(imkitchen_web_public::routes::health::health))

--- a/templates/_admin.html
+++ b/templates/_admin.html
@@ -15,6 +15,10 @@
             class="text-cream/60 hover:text-cream transition" {% endif %}>
             Users
           </a>
+          <a href="/admin/recipes/import" {% if current_path=="recipes" %} class="text-cream font-semibold" {% else %}
+            class="text-cream/60 hover:text-cream transition" {% endif %}>
+            Recipes
+          </a>
           <a href="/admin/invoices" {% if current_path=="invoices" %} class="text-cream font-semibold" {% else %}
             class="text-cream/60 hover:text-cream transition" {% endif %}>
             Invoices
@@ -42,6 +46,15 @@
           </path>
         </svg>
         <span class="text-xs mt-1 font-semibold">Users</span>
+      </a>
+      <a href="/admin/recipes/import" {% if current_path=="recipes" %}class="flex flex-col items-center py-2 px-3 text-cream"
+        {% else %}class="flex flex-col items-center py-2 px-3 text-cream/50" {% endif %}>
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12">
+          </path>
+        </svg>
+        <span class="text-xs mt-1">Recipes</span>
       </a>
       <a href="/admin/invoices" {% if current_path=="invoices" %}class="flex flex-col items-center py-2 px-3 text-cream"
         {% else %}class="flex flex-col items-center py-2 px-3 text-cream/50" {% endif %}>

--- a/templates/admin-recipes-import.html
+++ b/templates/admin-recipes-import.html
@@ -1,0 +1,133 @@
+{% extends "_admin.html" %}
+{% block title %}{{ "Batch Import Recipes - Admin"|t }}{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-6 max-w-3xl pb-24">
+
+  <header class="mb-6">
+    <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3">
+      {{ "Admin"|t }} <span class="mx-1">/</span> {{ "Recipes"|t }}
+    </div>
+    <h1 class="font-serif text-2xl md:text-3xl leading-tight tracking-tight text-ink mt-0.5">
+      {{ "Batch import recipes"|t }}
+    </h1>
+    <p class="text-sm text-ink-2 mt-2 leading-relaxed">
+      {{ "Upload a .zip archive of recipes grouped by author. Each author becomes a Chef account."|t }}
+    </p>
+  </header>
+
+  {# ── Drop zone ── #}
+  <label for="archive" class="block">
+    <div id="archive-drop"
+      class="border-2 border-dashed border-primary-300 bg-primary-50/60 rounded-3xl p-8 md:p-12 text-center cursor-pointer
+        hover:border-primary-500 hover:bg-primary-50 transition">
+      <div class="w-14 h-14 mx-auto mb-4 rounded-2xl bg-primary-500 text-white flex items-center justify-center shadow-md">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+        </svg>
+      </div>
+      <div class="font-serif text-xl md:text-2xl text-ink tracking-tight leading-tight">
+        {{ "Drop a .zip archive"|t }}
+      </div>
+      <p class="text-sm text-ink-2 mt-2 max-w-xs mx-auto leading-relaxed">
+        {{ "or click to browse"|t }}
+      </p>
+      <div class="inline-flex items-center gap-1.5 mt-5 h-10 px-4 bg-ink hover:bg-ink-2 text-cream text-sm font-semibold rounded-2xl shadow-sm transition">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+        </svg>
+        {{ "Choose file"|t }}
+      </div>
+      <p class="text-[11px] font-mono uppercase tracking-wider text-ink-3 mt-5">
+        {{ "Max 50MB · ZIP only"|t }}
+      </p>
+      <input type="file" id="archive" class="hidden" accept=".zip,application/zip"/>
+    </div>
+  </label>
+
+  {# ── Status / results area (filled in by JS after POST) ── #}
+  <div id="admin-import-area" class="mt-4"></div>
+
+  {# ── Archive layout doc ── #}
+  <section class="mt-6">
+    <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-2">
+      {{ "Archive layout"|t }}
+    </div>
+    <div class="bg-paper border border-line-2 rounded-2xl p-4 md:p-5">
+      <p class="text-sm text-ink-2 leading-relaxed mb-3">
+        {{ "One folder per author. Each recipe is a .json file (same schema as the user import) with an optional image of the same name."|t }}
+      </p>
+      <div class="bg-cream border border-line-2 rounded-xl p-3 md:p-4 overflow-x-auto">
+        <pre class="text-[11px] md:text-xs font-mono text-ink-2 leading-relaxed"><code>gordon_ramsay/
+  beef-wellington.json
+  beef-wellington.jpg
+  scrambled-eggs.json
+julia_child/
+  boeuf-bourguignon.json
+  boeuf-bourguignon.png</code></pre>
+      </div>
+      <p class="text-xs text-ink-3 mt-3 leading-relaxed">
+        {{ "Folder names are converted to a Chef username (3-15 letters, digits or underscores). A Chef account recipe+{username}@imkitchen.app is created if it does not already exist."|t }}
+      </p>
+    </div>
+
+    <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-2 mt-6 flex items-baseline gap-2">
+      <span>{{ "Recipe JSON schema"|t }}</span>
+      <span class="font-sans normal-case tracking-normal text-ink-3 font-normal text-[11px]">· v1.0</span>
+    </div>
+    <div class="bg-cream border border-line-2 rounded-xl p-3 md:p-4 overflow-x-auto">
+      <pre class="text-[11px] md:text-xs font-mono text-ink-2 leading-relaxed"><code>{
+  "name": "Thai Red Curry", (min 3, max 100)
+  "origin": "https://example.com/recipe", (url, min 10, max 255, optional)
+  "description": "Spicy coconut curry", (min 3, max 2000)
+  "recipe_type": "Appetizer|MainCourse|Dessert|Accompaniment|Beverage|Condiment",
+  "household_size": 2, (u16 &gt; 0)
+  "prep_time": 15, ({{ "minutes > 0"|t }})
+  "cook_time": 30, ({{ "minutes > 0"|t }})
+  "ingredients": [
+    { "quantity": 500, "unit": "G|ML", "name": "Chicken breast", "category": null },
+    { "quantity": 1, "unit": null, "name": "Lemon",
+      "category": "Frozen|Refrigerated|Grocery|FruitsAndVegetables|Butcher|Seafood|DairyAndEggs|Bakery|SnacksAndConfectionery" }
+  ],
+  "instructions": [
+    { "description": "Heat oil in wok", "time_next": 12 ({{ "time to wait before next instruction, minutes >= 0"|t }}) }
+  ],
+  "advance_prep": "Marinate chicken 2 hours before", ({{ "optional"|t }})
+  "dietary_restrictions": ["Vegetarian|Vegan|GlutenFree|DairyFree|NutFree"],
+  "accepts_accompaniment": false
+}</code></pre>
+    </div>
+  </section>
+</div>
+
+<script>
+  (() => {
+    const area = document.getElementById("admin-import-area");
+    const input = document.getElementById("archive");
+    const drop = document.getElementById("archive-drop");
+
+    async function upload(file) {
+      if (!file) return;
+      const form = new FormData();
+      form.append("archive", file, file.name);
+      try {
+        const resp = await fetch("/admin/recipes/import", { method: "POST", body: form });
+        const html = await resp.text();
+        area.innerHTML = html;
+        if (window.twinspark) {
+          window.twinspark.activate(area);
+        }
+      } catch (err) {
+        console.error("admin import error:", err);
+      }
+    }
+
+    drop.addEventListener("dragover", (e) => { e.preventDefault(); }, false);
+    drop.addEventListener("drop", (e) => {
+      e.preventDefault();
+      upload(e.dataTransfer.files[0]);
+    });
+    input.addEventListener("change", (e) => upload(e.target.files[0]));
+  })();
+</script>
+{% endblock %}

--- a/templates/partials/admin-recipes-importing-status.html
+++ b/templates/partials/admin-recipes-importing-status.html
@@ -1,0 +1,34 @@
+{% if let Some(result) = result %}
+<div>
+  <div class="bg-herb-50 border border-herb-200 rounded-2xl p-4 mb-3 flex items-start gap-3">
+    <svg class="w-5 h-5 text-herb-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    <div class="flex-1 min-w-0">
+      <div class="font-semibold text-sm text-herb-900">{{ "Import complete"|t }}</div>
+      <div class="text-xs text-herb-700 mt-1 leading-relaxed">
+        {{ "Imported"|t }} {{ result.recipes_imported }} {{ "recipe(s) across"|t }} {{ result.authors_total }} {{ "author(s)."|t }}
+      </div>
+    </div>
+  </div>
+
+  {% for error in result.errors %}
+  <div class="bg-red-50 border border-red-200 rounded-2xl p-4 mb-3 flex items-start gap-3">
+    <svg class="w-5 h-5 text-red-600 shrink-0 mt-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+    </svg>
+    <div class="flex-1 min-w-0">
+      <div class="font-semibold text-sm text-red-900">
+        <span class="text-[10px] font-mono uppercase tracking-wider text-red-500 mr-1">{{ error.scope }}</span>
+        {{ error.name }}
+      </div>
+      <div class="text-xs text-red-700 mt-1 leading-relaxed">{{ error.message }}</div>
+    </div>
+  </div>
+  {% endfor %}
+
+  <div ts-trigger="load" ts-action="remove #admin-importing-alert"></div>
+</div>
+{% else %}
+<div ts-trigger="load delay 800ms" ts-req="/admin/recipes/import/{{ job_id }}/status"></div>
+{% endif %}

--- a/templates/partials/admin-recipes-importing.html
+++ b/templates/partials/admin-recipes-importing.html
@@ -1,0 +1,20 @@
+<div>
+  <div id="admin-importing-alert"
+    class="bg-paper border border-line-2 rounded-2xl p-5 md:p-6 flex flex-col items-center text-center mb-3">
+    <div class="w-14 h-14 rounded-2xl bg-primary-500 text-white flex items-center justify-center shadow-md mb-4">
+      <svg class="w-7 h-7" style="animation: ikspin 1.2s linear infinite" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+      </svg>
+    </div>
+    <div class="font-serif text-xl md:text-2xl text-ink tracking-tight leading-tight">
+      {{ "Importing recipes…"|t }}
+    </div>
+    <p class="text-sm text-ink-2 mt-2 max-w-xs leading-relaxed">
+      {{ "Creating Chef accounts and importing recipes"|t }}
+    </p>
+    <div class="text-[10px] font-mono uppercase tracking-widest text-ink-3 mt-4">
+      {{ "This may take a while for large archives"|t }}
+    </div>
+  </div>
+  <div ts-trigger="load delay 500ms" ts-req="/admin/recipes/import/{{ job_id }}/status"></div>
+</div>

--- a/web/admin/Cargo.toml
+++ b/web/admin/Cargo.toml
@@ -8,12 +8,23 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 askama = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 time = { workspace = true }
 strum = { workspace = true }
 evento = { workspace = true }
+tokio = { workspace = true }
+zip = { workspace = true }
+ulid = { workspace = true }
 imkitchen-billing = { path = "../../crates/billing", version = "1.1.4" }
 imkitchen-core = { path = "../../crates/core", version = "1.1.4" }
 imkitchen-types = { path = "../../crates/types", version = "1.1.4" }
 imkitchen-identity = { path = "../../crates/identity", version = "1.1.4" }
 imkitchen-web-shared = { path = "../shared", version = "1.1.4" }
+
+[dev-dependencies]
+tokio = { workspace = true }
+temp-dir = { workspace = true }
+sqlx = { workspace = true }
+image = { workspace = true }
+imkitchen-db = { path = "../../crates/db", version = "1.1.4" }

--- a/web/admin/src/import.rs
+++ b/web/admin/src/import.rs
@@ -1,0 +1,380 @@
+//! Admin batch recipe import from a ZIP archive.
+//!
+//! Expected archive layout (a wrapping top-level folder is tolerated):
+//! ```text
+//! {author}/{recipe_slug}.json                      # recipe payload (same schema as user import)
+//! {author}/{recipe_slug}.{jpg|jpeg|png|webp}       # optional thumbnail for that recipe
+//! ```
+//!
+//! Each `{author}` folder maps to a Chef account `recipe+{username}@imkitchen.app`, where
+//! `username` is the folder name sanitized to the username rules. The account is created (as a
+//! Chef) if it does not exist; an existing non-Chef account is reported as an error and skipped.
+
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Cursor, Read};
+
+use evento::Executor;
+use imkitchen_identity::RegisterInput;
+use imkitchen_identity::types::user::Role;
+use imkitchen_types::recipe::{DietaryRestriction, Ingredient, Instruction, RecipeType};
+use imkitchen_web_shared::template::SERVER_ERROR_MESSAGE;
+use imkitchen_web_shared::{AdminImportError, AdminImportProgress};
+use serde::Deserialize;
+
+/// One recipe payload, matching the user-facing import schema (`schema.json` v1.0).
+#[derive(Deserialize)]
+struct RecipeJson {
+    recipe_type: RecipeType,
+    name: String,
+    origin: Option<String>,
+    description: String,
+    household_size: u16,
+    prep_time: u16,
+    cook_time: u16,
+    ingredients: Vec<Ingredient>,
+    instructions: Vec<Instruction>,
+    advance_prep: Option<String>,
+    #[serde(default)]
+    dietary_restrictions: Vec<DietaryRestriction>,
+    accepts_accompaniment: bool,
+}
+
+#[derive(Default)]
+struct ZipEntry {
+    json: Option<Vec<u8>>,
+    image: Option<Vec<u8>>,
+}
+
+/// Sanitize an author folder name into a valid username (3-15 chars, `[a-z0-9_]`).
+///
+/// Letters and digits are lowercased and kept; spaces, hyphens and underscores collapse to a
+/// single underscore; everything else is dropped. Returns `None` when the result cannot satisfy
+/// the minimum length.
+pub fn sanitize_username(folder: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut prev_underscore = false;
+
+    for c in folder.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            prev_underscore = false;
+        } else if (c == '_' || c == '-' || c == ' ') && !out.is_empty() && !prev_underscore {
+            out.push('_');
+            prev_underscore = true;
+        }
+    }
+
+    while out.ends_with('_') {
+        out.pop();
+    }
+
+    if out.chars().count() > 15 {
+        out = out.chars().take(15).collect();
+        while out.ends_with('_') {
+            out.pop();
+        }
+    }
+
+    if out.chars().count() < 3 {
+        return None;
+    }
+
+    Some(out)
+}
+
+/// Convert a command error into a user-facing message, logging server errors.
+fn user_message(err: imkitchen_core::Error) -> String {
+    match err {
+        imkitchen_core::Error::Server(e) => {
+            tracing::error!(err = %e, "admin batch import server error");
+            SERVER_ERROR_MESSAGE.to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+fn parse_recipe(bytes: &[u8]) -> Result<imkitchen_core::recipe::ImportInput, String> {
+    let recipe: RecipeJson =
+        serde_json::from_slice(bytes).map_err(|e| format!("Invalid JSON: {e}"))?;
+
+    Ok(imkitchen_core::recipe::ImportInput {
+        recipe_type: recipe.recipe_type,
+        name: recipe.name,
+        origin: recipe.origin,
+        description: recipe.description,
+        household_size: recipe.household_size,
+        prep_time: recipe.prep_time,
+        cook_time: recipe.cook_time,
+        ingredients: recipe.ingredients,
+        instructions: recipe.instructions,
+        advance_prep: recipe.advance_prep.unwrap_or_default(),
+        accepts_accompaniment: recipe.accepts_accompaniment,
+        dietary_restrictions: recipe.dietary_restrictions,
+    })
+}
+
+/// Resolve the Chef account for `username`, creating it if necessary.
+///
+/// Returns the chef id on success, or a user-facing error message describing why this author
+/// could not be processed.
+async fn resolve_or_create_chef<E: Executor + Clone>(
+    identity: &imkitchen_identity::Module<E>,
+    admin_id: &str,
+    username: &str,
+    password: &str,
+    cache: &mut HashMap<String, String>,
+) -> Result<String, String> {
+    if let Some(id) = cache.get(username) {
+        return Ok(id.clone());
+    }
+
+    let email = format!("recipe+{username}@imkitchen.app");
+
+    let id = match identity.find_account(&email).await.map_err(user_message)? {
+        Some(account) => {
+            if account.role != Role::Chef {
+                return Err("An account already exists for this author but is not a Chef.".into());
+            }
+            account.id
+        }
+        None => {
+            let id = identity
+                .register(RegisterInput {
+                    email,
+                    password: password.to_string(),
+                    lang: "en".into(),
+                    timezone: "UTC".into(),
+                })
+                .await
+                .map_err(user_message)?;
+
+            identity
+                .change_role(&id, Role::Chef, admin_id)
+                .await
+                .map_err(user_message)?;
+
+            identity
+                .set_username(&id, username.to_string())
+                .await
+                .map_err(user_message)?;
+
+            id
+        }
+    };
+
+    cache.insert(username.to_string(), id.clone());
+    Ok(id)
+}
+
+/// Process a recipe ZIP archive end to end and return the resulting progress (with `done = true`).
+///
+/// `password` is used as the password for any Chef account created during the import.
+pub async fn process_zip<E: Executor + Clone>(
+    identity: &imkitchen_identity::Module<E>,
+    recipe: &imkitchen_core::recipe::Module<E>,
+    admin_id: &str,
+    password: &str,
+    zip_bytes: Vec<u8>,
+) -> AdminImportProgress {
+    let mut progress = AdminImportProgress::default();
+
+    let mut archive = match zip::ZipArchive::new(Cursor::new(zip_bytes)) {
+        Ok(archive) => archive,
+        Err(e) => {
+            progress.done = true;
+            progress.errors.push(AdminImportError {
+                scope: "author".into(),
+                name: "archive".into(),
+                message: format!("Invalid ZIP archive: {e}"),
+            });
+            return progress;
+        }
+    };
+
+    // Group entries by author folder, then by recipe slug.
+    let mut authors: BTreeMap<String, BTreeMap<String, ZipEntry>> = BTreeMap::new();
+
+    for i in 0..archive.len() {
+        let Ok(mut file) = archive.by_index(i) else {
+            continue;
+        };
+        if file.is_dir() {
+            continue;
+        }
+
+        let name = file.name().replace('\\', "/");
+        let parts: Vec<&str> = name.split('/').filter(|s| !s.is_empty()).collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let author = parts[parts.len() - 2].to_string();
+        let filename = parts[parts.len() - 1];
+        let Some((slug, ext)) = filename.rsplit_once('.') else {
+            continue;
+        };
+        let ext = ext.to_ascii_lowercase();
+        let is_json = ext == "json";
+        let is_image = matches!(ext.as_str(), "jpg" | "jpeg" | "png" | "webp");
+        if !is_json && !is_image {
+            continue;
+        }
+
+        let mut buf = Vec::new();
+        if file.read_to_end(&mut buf).is_err() {
+            continue;
+        }
+
+        let entry = authors
+            .entry(author)
+            .or_default()
+            .entry(slug.to_string())
+            .or_default();
+        if is_json {
+            entry.json = Some(buf);
+        } else {
+            entry.image = Some(buf);
+        }
+    }
+
+    progress.authors_total = authors.len();
+    let mut cache: HashMap<String, String> = HashMap::new();
+
+    for (author, recipes) in authors {
+        let Some(username) = sanitize_username(&author) else {
+            progress.errors.push(AdminImportError {
+                scope: "author".into(),
+                name: author,
+                message:
+                    "Could not derive a valid username (needs 3-15 letters, digits or underscores)."
+                        .into(),
+            });
+            continue;
+        };
+
+        let chef_id =
+            match resolve_or_create_chef(identity, admin_id, &username, password, &mut cache).await
+            {
+                Ok(id) => id,
+                Err(message) => {
+                    progress.errors.push(AdminImportError {
+                        scope: "author".into(),
+                        name: author,
+                        message,
+                    });
+                    continue;
+                }
+            };
+
+        for (slug, entry) in recipes {
+            let label = format!("{author}/{slug}");
+
+            let Some(json) = entry.json else {
+                progress.errors.push(AdminImportError {
+                    scope: "recipe".into(),
+                    name: label,
+                    message: "Image has no matching .json file.".into(),
+                });
+                continue;
+            };
+
+            let input = match parse_recipe(&json) {
+                Ok(input) => input,
+                Err(message) => {
+                    progress.errors.push(AdminImportError {
+                        scope: "recipe".into(),
+                        name: label,
+                        message,
+                    });
+                    continue;
+                }
+            };
+
+            let recipe_name = input.name.clone();
+            match recipe.import(input, &chef_id, Some(username.clone())).await {
+                Ok(recipe_id) => {
+                    progress.recipes_imported += 1;
+
+                    if let Some(image) = entry.image
+                        && let Err(e) = recipe.upload_thunmnail(&recipe_id, image, &chef_id).await
+                    {
+                        progress.errors.push(AdminImportError {
+                            scope: "recipe".into(),
+                            name: recipe_name.clone(),
+                            message: format!(
+                                "Recipe imported, but image failed: {}",
+                                user_message(e)
+                            ),
+                        });
+                    }
+
+                    // Imported recipes are published to the community (idempotent: a recipe that
+                    // is already shared is left unchanged).
+                    if let Err(e) = recipe
+                        .share_to_community(&recipe_id, &chef_id, username.clone())
+                        .await
+                    {
+                        progress.errors.push(AdminImportError {
+                            scope: "recipe".into(),
+                            name: recipe_name,
+                            message: format!(
+                                "Recipe imported, but sharing failed: {}",
+                                user_message(e)
+                            ),
+                        });
+                    }
+                }
+                Err(e) => {
+                    progress.errors.push(AdminImportError {
+                        scope: "recipe".into(),
+                        name: recipe_name,
+                        message: user_message(e),
+                    });
+                }
+            }
+        }
+    }
+
+    progress.done = true;
+    progress
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_username;
+
+    #[test]
+    fn sanitizes_common_names() {
+        assert_eq!(
+            sanitize_username("Jean Dupont").as_deref(),
+            Some("jean_dupont")
+        );
+        assert_eq!(
+            sanitize_username("Chef-Marie!").as_deref(),
+            Some("chef_marie")
+        );
+        assert_eq!(sanitize_username("chef_123").as_deref(), Some("chef_123"));
+    }
+
+    #[test]
+    fn rejects_too_short() {
+        assert_eq!(sanitize_username("a"), None);
+        assert_eq!(sanitize_username("!!"), None);
+        assert_eq!(sanitize_username("__"), None);
+    }
+
+    #[test]
+    fn truncates_to_fifteen() {
+        let out = sanitize_username("abcdefghijklmnopqrstuvwxyz").unwrap();
+        assert_eq!(out, "abcdefghijklmno");
+        assert!(out.chars().count() <= 15);
+    }
+
+    #[test]
+    fn collapses_separators_and_trims() {
+        assert_eq!(
+            sanitize_username("  John   Doe  ").as_deref(),
+            Some("john_doe")
+        );
+        assert_eq!(sanitize_username("--mike--").as_deref(), Some("mike"));
+    }
+}

--- a/web/admin/src/lib.rs
+++ b/web/admin/src/lib.rs
@@ -1,8 +1,14 @@
+pub mod import;
 pub mod routes;
 
 pub fn routes() -> axum::Router<imkitchen_web_shared::AppState> {
     use axum::routing::{get, post};
     axum::Router::new()
+        .route("/admin/recipes/import", get(routes::recipe_import::page))
+        .route(
+            "/admin/recipes/import/{id}/status",
+            get(routes::recipe_import::status),
+        )
         .route("/admin/users", get(routes::users::page))
         .route("/admin/users/{id}/suspend", post(routes::users::suspend))
         .route("/admin/users/{id}/activate", post(routes::users::activate))
@@ -24,4 +30,11 @@ pub fn routes() -> axum::Router<imkitchen_web_shared::AppState> {
             post(routes::contact::resolve),
         )
         .route("/admin/contact/{id}/reopen", post(routes::contact::reopen))
+}
+
+/// The ZIP upload endpoint is exported separately so the server can give it a larger request
+/// body limit than the global cap (it is merged after the global limit layer).
+pub fn upload_routes() -> axum::Router<imkitchen_web_shared::AppState> {
+    use axum::routing::post;
+    axum::Router::new().route("/admin/recipes/import", post(routes::recipe_import::action))
 }

--- a/web/admin/src/routes/mod.rs
+++ b/web/admin/src/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod contact;
 pub mod invoices;
+pub mod recipe_import;
 pub mod users;

--- a/web/admin/src/routes/recipe_import.rs
+++ b/web/admin/src/routes/recipe_import.rs
@@ -1,0 +1,114 @@
+use axum::{
+    extract::{Multipart, Path, State},
+    response::IntoResponse,
+};
+
+use imkitchen_web_shared::{
+    AdminImportProgress, AppState,
+    auth::AuthAdmin,
+    template::{Template, filters},
+};
+
+#[derive(askama::Template)]
+#[template(path = "admin-recipes-import.html")]
+pub struct ImportTemplate {
+    pub current_path: String,
+}
+
+impl Default for ImportTemplate {
+    fn default() -> Self {
+        Self {
+            current_path: "recipes".to_owned(),
+        }
+    }
+}
+
+#[derive(askama::Template)]
+#[template(path = "partials/admin-recipes-importing.html")]
+pub struct ImportingTemplate {
+    pub job_id: String,
+}
+
+#[derive(askama::Template)]
+#[template(path = "partials/admin-recipes-importing-status.html")]
+pub struct ImportingStatusTemplate {
+    pub job_id: String,
+    pub result: Option<AdminImportProgress>,
+}
+
+#[tracing::instrument(skip_all, fields(admin = admin.id))]
+pub async fn page(template: Template, admin: AuthAdmin) -> impl IntoResponse {
+    tracing::debug!("admin {} opened recipe import", admin.id);
+    template.render(ImportTemplate::default())
+}
+
+#[tracing::instrument(skip_all, fields(admin = admin.id))]
+pub async fn action(
+    template: Template,
+    State(app): State<AppState>,
+    admin: AuthAdmin,
+    mut multipart: Multipart,
+) -> impl IntoResponse {
+    let Some(field) = imkitchen_web_shared::try_response!(anyhow: multipart.next_field(), template)
+    else {
+        imkitchen_web_shared::try_response!(sync:
+            Err(imkitchen_core::Error::User("No file provided".into())),
+            template
+        )
+    };
+
+    let data = imkitchen_web_shared::try_response!(anyhow: field.bytes(), template);
+    let bytes = data.to_vec();
+
+    let job_id = ulid::Ulid::new().to_string();
+    {
+        let mut jobs = app.import_jobs.lock().unwrap_or_else(|e| e.into_inner());
+        jobs.insert(job_id.clone(), AdminImportProgress::default());
+    }
+
+    let app = app.clone();
+    let admin_id = admin.id.clone();
+    let job = job_id.clone();
+    tokio::spawn(async move {
+        let password = app.config.root.password.clone();
+        let progress = crate::import::process_zip(
+            &app.identity,
+            &app.core.recipe,
+            &admin_id,
+            &password,
+            bytes,
+        )
+        .await;
+        let mut jobs = app.import_jobs.lock().unwrap_or_else(|e| e.into_inner());
+        jobs.insert(job, progress);
+    });
+
+    template.render(ImportingTemplate { job_id })
+}
+
+#[tracing::instrument(skip_all, fields(admin = admin.id))]
+pub async fn status(
+    template: Template,
+    State(app): State<AppState>,
+    admin: AuthAdmin,
+    Path((id,)): Path<(String,)>,
+) -> impl IntoResponse {
+    tracing::debug!("admin {} polling import {id}", admin.id);
+
+    let result = {
+        let mut jobs = app.import_jobs.lock().unwrap_or_else(|e| e.into_inner());
+        match jobs.get(&id) {
+            // Finished: hand back the result once and drop it from the registry.
+            Some(p) if p.done => jobs.remove(&id),
+            // Still running: keep polling.
+            Some(_) => None,
+            // Unknown job (server restarted, or already consumed): stop polling.
+            None => Some(AdminImportProgress {
+                done: true,
+                ..Default::default()
+            }),
+        }
+    };
+
+    template.render(ImportingStatusTemplate { job_id: id, result })
+}

--- a/web/admin/tests/import.rs
+++ b/web/admin/tests/import.rs
@@ -1,0 +1,147 @@
+use std::io::{Cursor, Write};
+use std::str::FromStr;
+
+use evento::Sqlite;
+use evento::migrator::{Migrate, Plan};
+use image::{DynamicImage, ImageFormat, RgbImage};
+use imkitchen_core::State;
+use imkitchen_identity::RegisterInput;
+use imkitchen_identity::types::user::Role;
+use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
+use temp_dir::TempDir;
+use zip::write::SimpleFileOptions;
+
+async fn setup_test_state(path: std::path::PathBuf) -> anyhow::Result<State<Sqlite>> {
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite:{}", path.to_str().unwrap()))?
+        .create_if_missing(true);
+    let pool = SqlitePool::connect_with(opts).await?;
+    let mut conn = pool.acquire().await?;
+    imkitchen_db::migrator::<sqlx::Sqlite>()?
+        .run(&mut conn, &Plan::apply_all())
+        .await?;
+
+    Ok(State {
+        executor: pool.clone().into(),
+        read_db: pool.clone(),
+        write_db: pool,
+    })
+}
+
+fn recipe_json(name: &str) -> String {
+    format!(
+        r#"{{
+            "recipe_type": "MainCourse",
+            "name": "{name}",
+            "description": "A delicious test recipe",
+            "household_size": 4,
+            "prep_time": 20,
+            "cook_time": 40,
+            "ingredients": [{{ "quantity": 500, "unit": "G", "name": "Beef", "category": null }}],
+            "instructions": [{{ "description": "Cook everything thoroughly", "time_next": 0 }}],
+            "accepts_accompaniment": false,
+            "dietary_restrictions": []
+        }}"#
+    )
+}
+
+fn png_bytes() -> Vec<u8> {
+    let img = RgbImage::new(2, 2);
+    let mut out = Cursor::new(Vec::new());
+    DynamicImage::ImageRgb8(img)
+        .write_to(&mut out, ImageFormat::Png)
+        .unwrap();
+    out.into_inner()
+}
+
+fn build_zip() -> anyhow::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(Cursor::new(&mut buf));
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        // New chef, recipe with an image.
+        zip.start_file("gordon_ramsay/beef-wellington.json", opts)?;
+        zip.write_all(recipe_json("Beef Wellington").as_bytes())?;
+        zip.start_file("gordon_ramsay/beef-wellington.png", opts)?;
+        zip.write_all(&png_bytes())?;
+
+        // Same chef, recipe without an image.
+        zip.start_file("gordon_ramsay/scrambled-eggs.json", opts)?;
+        zip.write_all(recipe_json("Scrambled Eggs").as_bytes())?;
+
+        // Maps to an existing non-chef account -> should be skipped.
+        zip.start_file("existing_user/soup.json", opts)?;
+        zip.write_all(recipe_json("Tomato Soup").as_bytes())?;
+
+        // Folder name cannot be sanitized to a valid username -> author error.
+        zip.start_file("a!/orphan.json", opts)?;
+        zip.write_all(recipe_json("Orphan").as_bytes())?;
+
+        zip.finish()?;
+    }
+    Ok(buf)
+}
+
+#[tokio::test]
+async fn imports_recipes_and_creates_chef_accounts() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let state = setup_test_state(dir.child("db.sqlite3")).await?;
+
+    let identity = imkitchen_identity::Module::new(state.clone());
+    let recipe = imkitchen_core::recipe::Module::new(state.clone());
+
+    // Pre-create a plain (non-chef) account that author "existing_user" maps to.
+    identity
+        .register(RegisterInput {
+            email: "recipe+existing_user@imkitchen.app".to_owned(),
+            password: "my_password".to_owned(),
+            lang: "en".to_owned(),
+            timezone: "UTC".to_owned(),
+        })
+        .await?;
+
+    let zip_bytes = build_zip()?;
+
+    let progress = imkitchen_web_admin::import::process_zip(
+        &identity,
+        &recipe,
+        "admin-id",
+        "root_password",
+        zip_bytes,
+    )
+    .await;
+
+    assert!(progress.done);
+    assert_eq!(
+        progress.authors_total, 3,
+        "gordon_ramsay, existing_user, a!"
+    );
+    assert_eq!(progress.recipes_imported, 2, "both gordon_ramsay recipes");
+
+    // Two author-scope errors: non-chef account + un-sanitizable folder name.
+    assert_eq!(progress.errors.len(), 2);
+    assert!(progress.errors.iter().all(|e| e.scope == "author"));
+    assert!(
+        progress
+            .errors
+            .iter()
+            .any(|e| e.name == "existing_user" && e.message.contains("not a Chef"))
+    );
+    assert!(progress.errors.iter().any(|e| e.name == "a!"));
+
+    // A Chef account was created for the new author.
+    let chef = identity
+        .find_account("recipe+gordon_ramsay@imkitchen.app")
+        .await?
+        .expect("chef account created");
+    assert_eq!(chef.role, Role::Chef);
+
+    // The pre-existing account was left untouched (still not a chef).
+    let existing = identity
+        .find_account("recipe+existing_user@imkitchen.app")
+        .await?
+        .expect("existing account");
+    assert_ne!(existing.role, Role::Chef);
+
+    Ok(())
+}

--- a/web/shared/src/lib.rs
+++ b/web/shared/src/lib.rs
@@ -6,6 +6,6 @@ pub mod middleware;
 pub mod state;
 pub mod template;
 
-pub use state::AppState;
+pub use state::{AdminImportError, AdminImportJobs, AdminImportProgress, AppState};
 
 rust_i18n::i18n!("../../locales", fallback = "en");

--- a/web/shared/src/state.rs
+++ b/web/shared/src/state.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use evento::Evento;
 
@@ -10,6 +12,7 @@ pub struct AppState {
     pub identity: imkitchen_identity::Module<Evento>,
     pub billing: imkitchen_billing::Billing<Evento>,
     pub core: imkitchen_core::Core<Evento>,
+    pub import_jobs: AdminImportJobs,
 }
 
 impl Deref for AppState {
@@ -19,3 +22,25 @@ impl Deref for AppState {
         &self.inner
     }
 }
+
+/// One error encountered while processing an admin batch import. `scope` is either
+/// `"author"` (the whole author folder was skipped) or `"recipe"` (a single recipe failed).
+#[derive(Clone, Default)]
+pub struct AdminImportError {
+    pub scope: String,
+    pub name: String,
+    pub message: String,
+}
+
+/// Progress / result of a single admin batch-import job, tracked in memory while the
+/// background task runs and read back by the status-polling endpoint.
+#[derive(Clone, Default)]
+pub struct AdminImportProgress {
+    pub done: bool,
+    pub authors_total: usize,
+    pub recipes_imported: usize,
+    pub errors: Vec<AdminImportError>,
+}
+
+/// In-memory registry of running/completed import jobs, keyed by job id.
+pub type AdminImportJobs = Arc<Mutex<HashMap<String, AdminImportProgress>>>;


### PR DESCRIPTION
## Context

Premium users can already import recipes one JSON at a time. This adds an **admin-only** bulk import that ingests a single ZIP and attaches recipes to per-author **Chef** accounts.

Archive layout (a wrapping top-level folder is tolerated):

```
{author}/{recipe_slug}.json                    # recipe payload (same schema as user import)
{author}/{recipe_slug}.{jpg|jpeg|png|webp}     # optional thumbnail for that recipe
```

## What it does

- New page at **`/admin/recipes/import`** (guarded by `AuthAdmin`); upload runs as an **async background job** with status polling, mirroring the existing import-status UX.
- **Per author folder** → sanitized into a valid username (3–15 chars, `[a-z0-9_]`). If it can't be made valid, that author is reported as an error and skipped.
- **Account resolution** keyed by `recipe+{username}@imkitchen.app`:
  - missing → create the account, promote it to **Chef**, set the username (password = configured **root password**);
  - existing **non-Chef** → skip with an error (no auto-promote);
  - existing **Chef** → reused.
- **Recipes** imported under the chef via the existing `recipe.import` (owner = chef id ⇒ re-imports are idempotent per chef); the matching **image is attached as the thumbnail** (optional); each imported recipe is **shared to the community** (idempotent via the existing `is_shared` guard).

## Implementation notes

- The global 1MB body limit blocks ZIPs, so the POST route is exported separately (`upload_routes()`) and merged **after** the global limit layer with its own **50MB** `RequestBodyLimitLayer`.
- Account lookup is keyed by the deterministic email — added a public `identity.find_account(email)` returning id/role/state from the aggregate (no username `FindType` needed).
- Background jobs are tracked in an in-memory `import_jobs` map on `AppState`; on server restart an in-flight job is lost and the status endpoint reports done to stop polling.

## Files

- New: `web/admin/src/import.rs`, `web/admin/src/routes/recipe_import.rs`, `web/admin/tests/import.rs`, `templates/admin-recipes-import.html`, `templates/partials/admin-recipes-importing{,-status}.html`
- Modified: `web/admin/src/lib.rs`, `web/admin/src/routes/mod.rs`, `web/admin/Cargo.toml`, `web/shared/src/{state.rs,lib.rs}`, `crates/identity/src/root/mod.rs`, `src/cli/server.rs`, `templates/_admin.html`, workspace `Cargo.toml`

## Testing

- Unit tests for `sanitize_username` (4 cases).
- Integration test building an in-memory ZIP across 3 authors (new chef w/ image + no-image, existing non-chef skipped, un-sanitizable folder errored) asserting counts, error scopes, and chef creation.
- `cargo build`, `cargo clippy`, and `cargo test` clean across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)