### PR TITLE
feat(identity): increase username max length from 15 to 25

### DIFF
--- a/crates/db/src/user_admin.rs
+++ b/crates/db/src/user_admin.rs
@@ -54,7 +54,7 @@ pub(crate) mod m0001 {
                     .string_len(320),
             )
             .col(ColumnDef::new(UserAdmin::FullName).string().string_len(25))
-            .col(ColumnDef::new(UserAdmin::Username).string().string_len(15))
+            .col(ColumnDef::new(UserAdmin::Username).string().string_len(30))
             .col(
                 ColumnDef::new(UserAdmin::State)
                     .string()

--- a/crates/db/src/user_admin.rs
+++ b/crates/db/src/user_admin.rs
@@ -54,7 +54,7 @@ pub(crate) mod m0001 {
                     .string_len(320),
             )
             .col(ColumnDef::new(UserAdmin::FullName).string().string_len(25))
-            .col(ColumnDef::new(UserAdmin::Username).string().string_len(30))
+            .col(ColumnDef::new(UserAdmin::Username).string().string_len(25))
             .col(
                 ColumnDef::new(UserAdmin::State)
                     .string()

--- a/crates/db/src/user_login.rs
+++ b/crates/db/src/user_login.rs
@@ -31,7 +31,7 @@ pub(crate) mod m0001 {
                     .primary_key(),
             )
             .col(ColumnDef::new(UserLogin::Cursor).string().not_null())
-            .col(ColumnDef::new(UserLogin::Username).string().string_len(30))
+            .col(ColumnDef::new(UserLogin::Username).string().string_len(25))
             .col(ColumnDef::new(UserLogin::Logins).blob().not_null())
             .col(
                 ColumnDef::new(UserLogin::Role)

--- a/crates/db/src/user_login.rs
+++ b/crates/db/src/user_login.rs
@@ -31,7 +31,7 @@ pub(crate) mod m0001 {
                     .primary_key(),
             )
             .col(ColumnDef::new(UserLogin::Cursor).string().not_null())
-            .col(ColumnDef::new(UserLogin::Username).string().string_len(15))
+            .col(ColumnDef::new(UserLogin::Username).string().string_len(30))
             .col(ColumnDef::new(UserLogin::Logins).blob().not_null())
             .col(
                 ColumnDef::new(UserLogin::Role)

--- a/crates/identity/src/root/set_username.rs
+++ b/crates/identity/src/root/set_username.rs
@@ -10,7 +10,7 @@ static RE_ALPHA_NUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[A-Za-z0-9
 
 #[derive(Validate)]
 pub struct SetUsernameInput {
-    #[validate(length(min = 3, max = 15), regex(path = *RE_ALPHA_NUM, message = "Only letters (A-Z, a-z) and numbers (0-9) are allowed."))]
+    #[validate(length(min = 3, max = 30), regex(path = *RE_ALPHA_NUM, message = "Only letters (A-Z, a-z) and numbers (0-9) are allowed."))]
     pub username: String,
 }
 

--- a/crates/identity/src/root/set_username.rs
+++ b/crates/identity/src/root/set_username.rs
@@ -10,7 +10,7 @@ static RE_ALPHA_NUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[A-Za-z0-9
 
 #[derive(Validate)]
 pub struct SetUsernameInput {
-    #[validate(length(min = 3, max = 30), regex(path = *RE_ALPHA_NUM, message = "Only letters (A-Z, a-z) and numbers (0-9) are allowed."))]
+    #[validate(length(min = 3, max = 25), regex(path = *RE_ALPHA_NUM, message = "Only letters (A-Z, a-z) and numbers (0-9) are allowed."))]
     pub username: String,
 }
 

--- a/templates/partials/set-username-modal.html
+++ b/templates/partials/set-username-modal.html
@@ -19,7 +19,7 @@
       <div class="space-y-4">
         <div>
           <label class="block text-sm font-semibold text-ink-2 mb-2">{{ "Username"|t }}</label>
-          <input autofocus autocomplete="off" type="text" name="username" minlength="3" maxlength="30" required
+          <input autofocus autocomplete="off" type="text" name="username" minlength="3" maxlength="25" required
 pattern="[a-zA-Z0-9_]+" title="{{ "Only alphanumeric characters allowed"|t }}" placeholder="{{ "Enter your username, eg. john_doe"|t }}"
             class="w-full px-4 py-2 border border-line rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none" />
           <p class="mt-2 text-sm text-ink-3">{{ "This will be visible to other users."|t }}</p>

--- a/templates/partials/set-username-modal.html
+++ b/templates/partials/set-username-modal.html
@@ -19,7 +19,7 @@
       <div class="space-y-4">
         <div>
           <label class="block text-sm font-semibold text-ink-2 mb-2">{{ "Username"|t }}</label>
-          <input autofocus autocomplete="off" type="text" name="username" minlength="3" maxlength="15" required
+          <input autofocus autocomplete="off" type="text" name="username" minlength="3" maxlength="30" required
 pattern="[a-zA-Z0-9_]+" title="{{ "Only alphanumeric characters allowed"|t }}" placeholder="{{ "Enter your username, eg. john_doe"|t }}"
             class="w-full px-4 py-2 border border-line rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none" />
           <p class="mt-2 text-sm text-ink-3">{{ "This will be visible to other users."|t }}</p>

--- a/web/admin/src/import.rs
+++ b/web/admin/src/import.rs
@@ -45,7 +45,7 @@ struct ZipEntry {
     image: Option<Vec<u8>>,
 }
 
-/// Sanitize an author folder name into a valid username (3-15 chars, `[a-z0-9_]`).
+/// Sanitize an author folder name into a valid username (3-30 chars, `[a-z0-9_]`).
 ///
 /// Letters and digits are lowercased and kept; spaces, hyphens and underscores collapse to a
 /// single underscore; everything else is dropped. Returns `None` when the result cannot satisfy
@@ -68,8 +68,8 @@ pub fn sanitize_username(folder: &str) -> Option<String> {
         out.pop();
     }
 
-    if out.chars().count() > 15 {
-        out = out.chars().take(15).collect();
+    if out.chars().count() > 30 {
+        out = out.chars().take(30).collect();
         while out.ends_with('_') {
             out.pop();
         }
@@ -245,7 +245,7 @@ pub async fn process_zip<E: Executor + Clone>(
                 scope: "author".into(),
                 name: author,
                 message:
-                    "Could not derive a valid username (needs 3-15 letters, digits or underscores)."
+                    "Could not derive a valid username (needs 3-30 letters, digits or underscores)."
                         .into(),
             });
             continue;
@@ -363,10 +363,10 @@ mod tests {
     }
 
     #[test]
-    fn truncates_to_fifteen() {
-        let out = sanitize_username("abcdefghijklmnopqrstuvwxyz").unwrap();
-        assert_eq!(out, "abcdefghijklmno");
-        assert!(out.chars().count() <= 15);
+    fn truncates_to_thirty() {
+        let out = sanitize_username("abcdefghijklmnopqrstuvwxyzabcdefghijklmn").unwrap();
+        assert_eq!(out, "abcdefghijklmnopqrstuvwxyzabcd");
+        assert!(out.chars().count() <= 30);
     }
 
     #[test]

--- a/web/admin/src/import.rs
+++ b/web/admin/src/import.rs
@@ -45,7 +45,7 @@ struct ZipEntry {
     image: Option<Vec<u8>>,
 }
 
-/// Sanitize an author folder name into a valid username (3-30 chars, `[a-z0-9_]`).
+/// Sanitize an author folder name into a valid username (3-25 chars, `[a-z0-9_]`).
 ///
 /// Letters and digits are lowercased and kept; spaces, hyphens and underscores collapse to a
 /// single underscore; everything else is dropped. Returns `None` when the result cannot satisfy
@@ -68,8 +68,8 @@ pub fn sanitize_username(folder: &str) -> Option<String> {
         out.pop();
     }
 
-    if out.chars().count() > 30 {
-        out = out.chars().take(30).collect();
+    if out.chars().count() > 25 {
+        out = out.chars().take(25).collect();
         while out.ends_with('_') {
             out.pop();
         }
@@ -245,7 +245,7 @@ pub async fn process_zip<E: Executor + Clone>(
                 scope: "author".into(),
                 name: author,
                 message:
-                    "Could not derive a valid username (needs 3-30 letters, digits or underscores)."
+                    "Could not derive a valid username (needs 3-25 letters, digits or underscores)."
                         .into(),
             });
             continue;
@@ -363,10 +363,10 @@ mod tests {
     }
 
     #[test]
-    fn truncates_to_thirty() {
+    fn truncates_to_twenty_five() {
         let out = sanitize_username("abcdefghijklmnopqrstuvwxyzabcdefghijklmn").unwrap();
-        assert_eq!(out, "abcdefghijklmnopqrstuvwxyzabcd");
-        assert!(out.chars().count() <= 30);
+        assert_eq!(out, "abcdefghijklmnopqrstuvwxy");
+        assert!(out.chars().count() <= 25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Raises the username character limit from **15** to **25** to be less restrictive while still fitting the UI. Updates every site where the limit is enforced or described so they stay consistent.

## Changes
- `crates/identity/src/root/set_username.rs` — validator `max = 15` → `25` (the actually-enforced limit)
- `crates/db/src/user_login.rs` / `crates/db/src/user_admin.rs` — `Username` column `string_len(15)` → `string_len(25)`
- `web/admin/src/import.rs` — ZIP-import sanitizer cap (`> 15` / `take(15)` → `25`), plus its doc comment, the user-facing error message, and the `truncates_to_twenty_five` test
- `templates/partials/set-username-modal.html` — client-side input `maxlength="15"` → `25`

`min = 3` and the `[A-Za-z0-9_]` rule are unchanged.

## Notes
- On SQLite, `string_len` isn't enforced at runtime, so existing rows/deployments are unaffected; the declared schema only applies to freshly-created tables.

## Test plan
- `cargo test -p imkitchen-web-admin --lib import::tests` — all pass (incl. updated `truncates_to_twenty_five`)
- `cargo build -p imkitchen-identity -p imkitchen-db` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)