### PR TITLE
fix(admin): use recipes+ prefix for import account emails

### DIFF
--- a/web/admin/src/import.rs
+++ b/web/admin/src/import.rs
@@ -6,7 +6,7 @@
 //! {author}/{recipe_slug}.{jpg|jpeg|png|webp}       # optional thumbnail for that recipe
 //! ```
 //!
-//! Each `{author}` folder maps to a Chef account `recipe+{username}@imkitchen.app`, where
+//! Each `{author}` folder maps to a Chef account `recipes+{username}@imkitchen.app`, where
 //! `username` is the folder name sanitized to the username rules. The account is created (as a
 //! Chef) if it does not exist; an existing non-Chef account is reported as an error and skipped.
 
@@ -128,7 +128,7 @@ async fn resolve_or_create_chef<E: Executor + Clone>(
         return Ok(id.clone());
     }
 
-    let email = format!("recipe+{username}@imkitchen.app");
+    let email = format!("recipes+{username}@imkitchen.app");
 
     let id = match identity.find_account(&email).await.map_err(user_message)? {
         Some(account) => {

--- a/web/admin/tests/import.rs
+++ b/web/admin/tests/import.rs
@@ -93,7 +93,7 @@ async fn imports_recipes_and_creates_chef_accounts() -> anyhow::Result<()> {
     // Pre-create a plain (non-chef) account that author "existing_user" maps to.
     identity
         .register(RegisterInput {
-            email: "recipe+existing_user@imkitchen.app".to_owned(),
+            email: "recipes+existing_user@imkitchen.app".to_owned(),
             password: "my_password".to_owned(),
             lang: "en".to_owned(),
             timezone: "UTC".to_owned(),
@@ -131,14 +131,14 @@ async fn imports_recipes_and_creates_chef_accounts() -> anyhow::Result<()> {
 
     // A Chef account was created for the new author.
     let chef = identity
-        .find_account("recipe+gordon_ramsay@imkitchen.app")
+        .find_account("recipes+gordon_ramsay@imkitchen.app")
         .await?
         .expect("chef account created");
     assert_eq!(chef.role, Role::Chef);
 
     // The pre-existing account was left untouched (still not a chef).
     let existing = identity
-        .find_account("recipe+existing_user@imkitchen.app")
+        .find_account("recipes+existing_user@imkitchen.app")
         .await?
         .expect("existing account");
     assert_ne!(existing.role, Role::Chef);


### PR DESCRIPTION
## Summary
- Admin batch recipe import now generates Chef account emails with the `recipes+{username}@imkitchen.app` prefix instead of `recipe+`.
- Updated the doc comment and tests accordingly.

## Test plan
- `cargo build -p imkitchen-web-admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)