### PR TITLE
fix(recipes): prevent long names overflowing in list view

### DIFF
--- a/templates/recipes-index.html
+++ b/templates/recipes-index.html
@@ -251,7 +251,7 @@
       ts-req="/recipes?after={{ cursor.to_string() }}{% if let Some(sort_by) = query.sort_by %}&sort_by={{ sort_by }}{% endif %}{% if let Some(recipe_type) = query.recipe_type %}&recipe_type={{ recipe_type }}{% endif %}{% if let Some(true) = query.in_meal_plan %}&in_meal_plan=true{% endif %}{% if let Some(true) = query.mine %}&mine=true{% endif %}{% if let Some(true) = query.no_image %}&no_image=true{% endif %}&view=list"
       ts-req-method="GET" ts-req-selector="children #recipes-list" ts-swap="afterend" ts-trigger="visible once"
       {% endif %}
-      class="bg-paper border border-line-2 rounded-2xl px-3 py-2.5 shadow-sm hover:shadow-md transition flex items-center gap-3">
+      class="min-w-0 bg-paper border border-line-2 rounded-2xl px-3 py-2.5 shadow-sm hover:shadow-md transition flex items-center gap-3">
       <div class="relative w-12 h-12 rounded-xl overflow-hidden bg-linear-to-br {% call type_hero_classes(rt) %}{% endcall %}
         flex items-center justify-center shrink-0">
         {% if let Some(version) = recipe.node.thumbnail_version %}


### PR DESCRIPTION
## Summary

Long recipe names overflowed the row in **list** view (grid view was already fixed via `line-clamp-2`).

The list-row `<a>` is a single-column `grid gap-2` item. Grid items default to `min-width: auto`, so a long unbroken name expanded the row past the container width — and the inner `truncate` had no constrained width to clamp against.

Adding `min-w-0` to the row lets the grid item shrink to the column, so the existing `flex-1 min-w-0` + `truncate` chain finally takes effect.

## Changes

- `templates/recipes-index.html`: add `min-w-0` to the list-row anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)