### PR TITLE
feat(mealplan): remove beverage and condiment from meal plan generation

### DIFF
--- a/crates/core/src/mealplan/root/generate.rs
+++ b/crates/core/src/mealplan/root/generate.rs
@@ -149,34 +149,6 @@ impl<E: Executor> super::Module<E> {
             };
             let mut dessert_recipes = dessert_recipes.iter();
 
-            let beverage_recipes = match input.randomize.as_ref() {
-                Some(opts) => {
-                    self.random(
-                        &input.user_id,
-                        RecipeType::Beverage,
-                        1.0,
-                        opts.dietary_restrictions.to_vec(),
-                    )
-                    .await?
-                }
-                _ => vec![],
-            };
-            let mut beverage_recipes = beverage_recipes.iter();
-
-            let condiment_recipes = match input.randomize.as_ref() {
-                Some(opts) => {
-                    self.random(
-                        &input.user_id,
-                        RecipeType::Condiment,
-                        1.0,
-                        opts.dietary_restrictions.to_vec(),
-                    )
-                    .await?
-                }
-                _ => vec![],
-            };
-            let mut condiment_recipes = condiment_recipes.iter();
-
             let accompaniment = if recipe.accepts_accompaniment && input.randomize.is_some() {
                 accompaniment_recipes.next().map(|r| r.into())
             } else {
@@ -191,8 +163,8 @@ impl<E: Executor> super::Module<E> {
                 main_course: recipe.into(),
                 dessert: dessert_recipes.next().map(|r| r.into()),
                 accompaniment,
-                beverage: beverage_recipes.next().map(|r| r.into()),
-                condiment: condiment_recipes.next().map(|r| r.into()),
+                beverage: None,
+                condiment: None,
             });
         }
 


### PR DESCRIPTION
## Summary

Meal plan generation no longer selects `Beverage` or `Condiment` recipes when building generated slots. These two categories are simply never scheduled into a meal plan.

Scope is intentionally minimal — **generation only**:
- The `RecipeType::Beverage` / `RecipeType::Condiment` variants are unchanged, so recipes can still be tagged with them.
- The `Slot.beverage` / `Slot.condiment` fields, DB columns, projections, and menu/kitchen templates are left in place; they now just always render empty for generated plans.

## Changes

`crates/core/src/mealplan/root/generate.rs`:
- Removed the `beverage_recipes` and `condiment_recipes` selection blocks from `generate()`.
- Set `beverage: None` and `condiment: None` in the `Slot { .. }` construction.

## Verification

- `cargo build -p imkitchen-core` — clean.
- `cargo test -p imkitchen-core` — all compiled tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)