### PR TITLE
feat(kitchen): embed imported recipe origins when framing is allowed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1988,8 +1988,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1999,9 +2001,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2321,6 +2325,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2345,13 +2350,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2574,7 +2582,7 @@ dependencies = [
  "imkitchen-web-shared",
  "sqlx",
  "tokio",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2613,6 +2621,7 @@ dependencies = [
  "imkitchen-db",
  "imkitchen-types",
  "rand 0.10.1",
+ "reqwest",
  "sea-query",
  "sea-query-sqlx",
  "serde",
@@ -2900,6 +2909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +2922,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3207,6 +3222,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -4846,6 +4867,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5083,6 +5159,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,7 +5424,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5335,6 +5449,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -6130,6 +6245,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -6164,7 +6282,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6519,6 +6637,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6945,6 +7081,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6974,6 +7120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7039,7 +7195,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ temp-dir = "0.2"
 rand = "0.10"
 tokio-cron-scheduler = "0.15"
 zip = { version = "8.0", default-features = false, features = ["deflate"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [package]
 name = "imkitchen"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ sea-query.workspace = true
 sea-query-sqlx.workspace = true
 time = { workspace = true }
 rand = { workspace = true }
+reqwest.workspace = true
 tracing.workspace = true
 time-tz.workspace = true
 imkitchen-types = { path = "../types", version = "1.2.0" }

--- a/crates/core/src/recipe/query/embeddable.rs
+++ b/crates/core/src/recipe/query/embeddable.rs
@@ -1,0 +1,144 @@
+use std::time::Duration;
+
+use evento::Executor;
+use imkitchen_db::origin_framing::OriginFraming;
+use sea_query::{Expr, ExprTrait, OnConflict, Query, SqliteQueryBuilder};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::SqlitePool;
+
+impl<E: Executor> crate::recipe::Module<E> {
+    /// Returns whether the site behind `origin` permits being embedded in an
+    /// iframe, from the per-domain `origin_framing` cache.
+    ///
+    /// This is a pure read — the actual header check is performed off the request
+    /// path by the background `recipe-saga-embeddable` subscription when a recipe
+    /// is imported or its origin changes (see [`crate::recipe::saga::embeddable`]).
+    /// A domain that has not been checked yet, or whose check failed, reads as
+    /// `false`, so the caller falls back to the native step UI / external link.
+    pub async fn is_origin_embeddable(&self, origin: &str) -> anyhow::Result<bool> {
+        let Some(domain) = domain_of(origin) else {
+            return Ok(false);
+        };
+
+        let statement = Query::select()
+            .column(OriginFraming::Embeddable)
+            .from(OriginFraming::Table)
+            .and_where(Expr::col(OriginFraming::Domain).eq(domain))
+            .to_owned();
+        let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+
+        Ok(
+            sqlx::query_as_with::<_, (bool,), _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&self.read_db)
+                .await?
+                .map(|(embeddable,)| embeddable)
+                .unwrap_or(false),
+        )
+    }
+}
+
+/// Lower-cased host of a URL, used as the per-domain cache key.
+pub(crate) fn domain_of(origin: &str) -> Option<String> {
+    reqwest::Url::parse(origin)
+        .ok()?
+        .host_str()
+        .map(str::to_ascii_lowercase)
+}
+
+/// Whether the `origin_framing` cache already holds a verdict for `domain`.
+pub(crate) async fn is_domain_cached(read_db: &SqlitePool, domain: &str) -> anyhow::Result<bool> {
+    let statement = Query::select()
+        .column(OriginFraming::Domain)
+        .from(OriginFraming::Table)
+        .and_where(Expr::col(OriginFraming::Domain).eq(domain.to_owned()))
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+
+    Ok(
+        sqlx::query_as_with::<_, (String,), _>(sqlx::AssertSqlSafe(sql), values)
+            .fetch_optional(read_db)
+            .await?
+            .is_some(),
+    )
+}
+
+/// Persists the framing verdict for `domain`, stamped with the current time.
+pub(crate) async fn store_verdict(
+    write_db: &SqlitePool,
+    domain: &str,
+    embeddable: bool,
+) -> anyhow::Result<()> {
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    let statement = Query::insert()
+        .into_table(OriginFraming::Table)
+        .columns([
+            OriginFraming::Domain,
+            OriginFraming::Embeddable,
+            OriginFraming::CheckedAt,
+        ])
+        .values_panic([domain.to_owned().into(), embeddable.into(), now.into()])
+        .on_conflict(
+            OnConflict::column(OriginFraming::Domain)
+                .update_columns([OriginFraming::Embeddable, OriginFraming::CheckedAt])
+                .to_owned(),
+        )
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+    sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
+        .execute(write_db)
+        .await?;
+
+    Ok(())
+}
+
+/// Fetches `origin` and inspects its framing headers. Returns `false` on any
+/// network/HTTP failure so blocked or unreachable sites degrade to the native
+/// fallback.
+pub(crate) async fn check_embeddable(origin: &str) -> bool {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(4))
+        .user_agent("Mozilla/5.0 (compatible; imkitchen)")
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+
+    let response = match client.get(origin).send().await {
+        Ok(response) => response,
+        Err(_) => return false,
+    };
+
+    let headers = response.headers();
+
+    // X-Frame-Options: DENY / SAMEORIGIN both forbid embedding on our origin.
+    if let Some(xfo) = headers
+        .get("x-frame-options")
+        .and_then(|value| value.to_str().ok())
+    {
+        let xfo = xfo.to_ascii_lowercase();
+        if xfo.contains("deny") || xfo.contains("sameorigin") {
+            return false;
+        }
+    }
+
+    // CSP frame-ancestors: only a wildcard source permits arbitrary embedders.
+    // 'none', 'self', or a specific host list all block us.
+    if let Some(csp) = headers
+        .get("content-security-policy")
+        .and_then(|value| value.to_str().ok())
+    {
+        let csp = csp.to_ascii_lowercase();
+        if let Some(idx) = csp.find("frame-ancestors") {
+            let directive = csp[idx + "frame-ancestors".len()..]
+                .split(';')
+                .next()
+                .unwrap_or("");
+            if !directive.contains('*') {
+                return false;
+            }
+        }
+    }
+
+    true
+}

--- a/crates/core/src/recipe/query/mod.rs
+++ b/crates/core/src/recipe/query/mod.rs
@@ -1,3 +1,4 @@
+pub mod embeddable;
 pub mod thumbnail;
 pub mod user;
 pub mod user_fts;

--- a/crates/core/src/recipe/saga/embeddable.rs
+++ b/crates/core/src/recipe/saga/embeddable.rs
@@ -1,0 +1,67 @@
+//! Background subscription that determines whether a recipe's `origin` site
+//! permits iframe embedding, caching the verdict per-domain in `origin_framing`.
+//!
+//! The check is a network side-effect — an HTTP GET reading `X-Frame-Options` /
+//! CSP `frame-ancestors` — so it runs here, off the request path, instead of
+//! lazily when the cooking screen is rendered. Because the cache is keyed by
+//! domain and framing policy is effectively site-wide, each domain is fetched at
+//! most once; recipes sharing a domain reuse the cached verdict, and a fresh
+//! deploy backfills every existing recipe's domain via the subscription replay.
+//! Request handlers ([`crate::recipe::Module::is_origin_embeddable`]) then only
+//! read the cache.
+
+use evento::{
+    Executor,
+    metadata::Event,
+    subscription::{Context, SubscriptionBuilder},
+};
+use imkitchen_types::recipe::{BasicInformationChanged, Imported};
+use sqlx::SqlitePool;
+
+use crate::recipe::query::embeddable::{check_embeddable, domain_of, is_domain_cached, store_verdict};
+
+pub fn subscription<E: Executor>() -> SubscriptionBuilder<E> {
+    SubscriptionBuilder::new("recipe-saga-embeddable")
+        .handler(handle_imported())
+        .handler(handle_basic_information_changed())
+}
+
+/// Checks `origin`'s framing headers once per domain and caches the verdict.
+async fn ensure_checked(
+    read_db: &SqlitePool,
+    write_db: &SqlitePool,
+    origin: Option<&str>,
+) -> anyhow::Result<()> {
+    let Some(origin) = origin else {
+        return Ok(());
+    };
+    let Some(domain) = domain_of(origin) else {
+        return Ok(());
+    };
+
+    // One network check per domain — skip if a verdict already exists.
+    if is_domain_cached(read_db, &domain).await? {
+        return Ok(());
+    }
+
+    let embeddable = check_embeddable(origin).await;
+    store_verdict(write_db, &domain, embeddable).await
+}
+
+#[evento::subscription]
+async fn handle_imported<E: Executor>(
+    context: &Context<'_, E>,
+    event: Event<Imported>,
+) -> anyhow::Result<()> {
+    let (read_db, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
+    ensure_checked(&read_db, &write_db, event.data.origin.as_deref()).await
+}
+
+#[evento::subscription]
+async fn handle_basic_information_changed<E: Executor>(
+    context: &Context<'_, E>,
+    event: Event<BasicInformationChanged>,
+) -> anyhow::Result<()> {
+    let (read_db, write_db) = context.extract::<(SqlitePool, SqlitePool)>();
+    ensure_checked(&read_db, &write_db, event.data.origin.as_deref()).await
+}

--- a/crates/core/src/recipe/saga/embeddable.rs
+++ b/crates/core/src/recipe/saga/embeddable.rs
@@ -18,7 +18,9 @@ use evento::{
 use imkitchen_types::recipe::{BasicInformationChanged, Imported};
 use sqlx::SqlitePool;
 
-use crate::recipe::query::embeddable::{check_embeddable, domain_of, is_domain_cached, store_verdict};
+use crate::recipe::query::embeddable::{
+    check_embeddable, domain_of, is_domain_cached, store_verdict,
+};
 
 pub fn subscription<E: Executor>() -> SubscriptionBuilder<E> {
     SubscriptionBuilder::new("recipe-saga-embeddable")

--- a/crates/core/src/recipe/saga/mod.rs
+++ b/crates/core/src/recipe/saga/mod.rs
@@ -15,6 +15,8 @@
 //! recipe-query read model, which may be mid-rebuild (e.g. right after the m0005
 //! truncate). That is what keeps the historical backfill race-free.
 
+pub mod embeddable;
+
 use evento::{
     Executor, ProjectionAggregate,
     metadata::Event,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -5,12 +5,14 @@ pub(crate) mod m0002;
 pub(crate) mod m0003;
 pub(crate) mod m0004;
 pub(crate) mod m0005;
+pub(crate) mod m0006;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
 pub mod mealplan_recipe;
 pub mod mealplan_slot;
 pub mod notification_recipient;
+pub mod origin_framing;
 pub mod recipe_owner;
 pub mod recipe_thumbnail;
 pub mod recipe_user;
@@ -37,6 +39,7 @@ where
     m0003::Migration: sqlx_migrator::Migration<DB>,
     m0004::Migration: sqlx_migrator::Migration<DB>,
     m0005::Migration: sqlx_migrator::Migration<DB>,
+    m0006::Migration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = evento::sql_migrator::new::<DB>()?;
     migrator.add_migrations(vec![
@@ -45,6 +48,7 @@ where
         Box::new(m0003::Migration),
         Box::new(m0004::Migration),
         Box::new(m0005::Migration),
+        Box::new(m0006::Migration),
     ])?;
 
     Ok(migrator)

--- a/crates/db/src/m0006/mod.rs
+++ b/crates/db/src/m0006/mod.rs
@@ -1,0 +1,11 @@
+use sqlx_migrator::vec_box;
+
+pub struct Migration;
+
+sqlx_migrator::sqlite_migration!(
+    Migration,
+    "imkitchen",
+    "m0006",
+    vec_box![super::m0005::Migration],
+    vec_box![crate::origin_framing::m0006::CreateTable]
+);

--- a/crates/db/src/origin_framing.rs
+++ b/crates/db/src/origin_framing.rs
@@ -1,0 +1,71 @@
+use sea_query::Iden;
+
+#[derive(Iden, Clone)]
+pub enum OriginFraming {
+    Table,
+    Domain,
+    Embeddable,
+    CheckedAt,
+}
+
+pub(crate) mod m0006 {
+    use sea_query::{ColumnDef, Table, TableCreateStatement, TableDropStatement};
+
+    use super::OriginFraming;
+
+    pub struct CreateTable;
+
+    fn create_table() -> TableCreateStatement {
+        Table::create()
+            .table(OriginFraming::Table)
+            .col(
+                ColumnDef::new(OriginFraming::Domain)
+                    .string()
+                    .string_len(255)
+                    .primary_key(),
+            )
+            .col(
+                ColumnDef::new(OriginFraming::Embeddable)
+                    .boolean()
+                    .not_null()
+                    .default(false),
+            )
+            .col(
+                ColumnDef::new(OriginFraming::CheckedAt)
+                    .big_integer()
+                    .not_null(),
+            )
+            .to_owned()
+    }
+
+    fn drop_table() -> TableDropStatement {
+        Table::drop().table(OriginFraming::Table).to_owned()
+    }
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for CreateTable {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            let statement = create_table().to_string(sea_query::SqliteQueryBuilder);
+            sqlx::query(sqlx::AssertSqlSafe(statement))
+                .execute(connection)
+                .await?;
+
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            let statement = drop_table().to_string(sea_query::SqliteQueryBuilder);
+            sqlx::query(sqlx::AssertSqlSafe(statement))
+                .execute(connection)
+                .await?;
+
+            Ok(())
+        }
+    }
+}

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -112,6 +112,12 @@ pub async fn serve(
         .start(&executor)
         .await?;
 
+    let sub_recipe_saga_embeddable = imkitchen_core::recipe::saga::embeddable::subscription()
+        .data((read_pool.clone(), write_pool.clone()))
+        .all()
+        .start(&executor)
+        .await?;
+
     let sub_recipe_user_fts = imkitchen_core::recipe::query::user_fts::subscription()
         .data(write_pool.clone())
         .all()
@@ -272,6 +278,7 @@ pub async fn serve(
         sub_recipe_command.shutdown(),
         sub_recipe_query.shutdown(),
         sub_recipe_saga_share.shutdown(),
+        sub_recipe_saga_embeddable.shutdown(),
         sub_recipe_user_fts.shutdown(),
         sub_recipe_user_stat.shutdown(),
         sub_recipe_thumbnail.shutdown(),

--- a/templates/partials/cooking-screen.html
+++ b/templates/partials/cooking-screen.html
@@ -50,6 +50,7 @@
     </a>
     <div class="flex-1 text-center min-w-0">
       <div class="text-[10px] font-mono tracking-widest uppercase text-ink-3">
+        {% if !show_iframe %}
         {% if let Some((pos, _)) = current_instruction %}
           {% if coming_instructions.is_empty() %}
             {{ "Cooking · final step"|t }}
@@ -57,13 +58,19 @@
             {{ "Cooking · step"|t }} {{ pos + 1 }} {{ "of"|t }} {{ slot_recipe.instructions.len() }}
           {% endif %}
         {% endif %}
+        {% endif %}
       </div>
       <div class="font-serif text-base leading-none mt-0.5 tracking-tight text-ink truncate">{{ slot_recipe.name }}</div>
     </div>
     <div class="w-9 shrink-0"></div>
   </header>
 
-  {% if let Some((pos, ins)) = current_instruction %}
+  {% if show_iframe %}
+  {# ── Imported recipe whose origin permits framing (checked server-side) ── #}
+  {% if let Some(origin) = slot_recipe.origin %}
+  <iframe class="w-full flex-1 border-0" src="{{ origin }}" loading="lazy"></iframe>
+  {% endif %}
+  {% else if let Some((pos, ins)) = current_instruction %}
   {# ── Progress dots ────────────────────────────────────────────── #}
   <div class="px-4 pb-1 flex gap-0.5">
     {% for _ in completed_instructions %}
@@ -168,8 +175,25 @@
     </div>
   </footer>
   {% else if let Some(origin) = slot_recipe.origin %}
-  {# ── Fallback for recipes imported from a URL but with no parsed steps ── #}
-  <iframe class="w-full flex-1 border-0" src="{{ origin }}" loading="lazy"></iframe>
+  {# ── Imported recipe with no parsed steps whose origin refuses framing:
+        link out to the original instead of embedding it. ── #}
+  <main class="flex-1 min-h-0 overflow-y-auto px-4 py-6 flex items-center justify-center">
+    <div class="bg-paper border border-line-2 rounded-2xl p-8 flex flex-col items-center text-center gap-4 max-w-md">
+      <svg class="w-10 h-10 text-ink-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+      </svg>
+      <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3">{{ "Imported"|t }}</div>
+      <p class="text-ink-2">{{ "This recipe was imported from an external source."|t }}</p>
+      <a href="{{ origin }}" target="_blank" rel="noopener noreferrer"
+        class="inline-flex items-center gap-2 px-5 py-2.5 bg-primary-500 hover:bg-primary-600 text-white text-sm font-semibold rounded-2xl shadow-sm transition">
+        {{ "Open Original Recipe"|t }}
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+        </svg>
+      </a>
+    </div>
+  </main>
   {% endif %}
 
   <script>

--- a/templates/partials/kitchen-dish.html
+++ b/templates/partials/kitchen-dish.html
@@ -132,11 +132,23 @@
       <p class="text-sm text-ink-2 mt-2 leading-relaxed max-w-prose">{{ slot_recipe.description }}</p>
       {% endif %}
       <div class="flex gap-2 mt-4">
+        {% if cook_external %}
+        {# ── Imported recipe with no in-app steps and an unframeable origin:
+              start straight from the original source in a new tab. ── #}
+        {% if let Some(origin) = slot_recipe.origin %}
+        <a href="{{ origin }}" target="_blank" rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 px-4 py-2.5 bg-ink text-cream rounded-xl text-sm font-semibold shadow-sm hover:opacity-90 transition">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M6 4l14 8-14 8V4z"/></svg>
+          {{ "Start cooking"|t }}
+        </a>
+        {% endif %}
+        {% else %}
         <a href="{{ "/kitchen/"|demo_href }}{{ date }}/{{ slot_recipe.id }}/cook"
           class="inline-flex items-center gap-2 px-4 py-2.5 bg-ink text-cream rounded-xl text-sm font-semibold shadow-sm hover:opacity-90 transition">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M6 4l14 8-14 8V4z"/></svg>
           {{ "Start cooking"|t }}
         </a>
+        {% endif %}
         <a href="{{ "/r/"|demo_href }}{{ slot_recipe.slug }}"
           class="inline-flex items-center gap-2 px-4 py-2.5 border border-line bg-paper/80 text-ink rounded-xl text-sm font-semibold hover:bg-paper transition">
           {{ "See recipe"|t }}

--- a/web/demo/src/fixtures.rs
+++ b/web/demo/src/fixtures.rs
@@ -612,6 +612,7 @@ pub fn cooking(recipe_id: &str) -> CookingTemplate {
         coming_instructions,
         current_instruction,
         date: ymd(today),
+        show_iframe: false,
     }
 }
 

--- a/web/kitchen/src/lib.rs
+++ b/web/kitchen/src/lib.rs
@@ -937,10 +937,11 @@ pub async fn cook_page(
     // Imported recipe with no parsed steps whose origin refuses framing: there is
     // nothing to show in-app, so send the user straight to the original instead of
     // rendering a "Open Original Recipe" button they'd have to tap.
-    if !show_iframe && current_instruction.is_none() {
-        if let Some(origin) = slot_recipe.origin.as_deref() {
-            return Redirect::to(origin).into_response();
-        }
+    if !show_iframe
+        && current_instruction.is_none()
+        && let Some(origin) = slot_recipe.origin.as_deref()
+    {
+        return Redirect::to(origin).into_response();
     }
 
     template

--- a/web/kitchen/src/lib.rs
+++ b/web/kitchen/src/lib.rs
@@ -1,5 +1,5 @@
 use axum::extract::{Path, State};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Redirect};
 use axum_extra::extract::CookieJar;
 use imkitchen_core::mealplan::slot::SlotRow;
 use imkitchen_core::mealplan::{ChangeSlotRecipeStatus, Recipe};
@@ -66,6 +66,9 @@ pub struct KitchenTemplate {
     /// Recipe id → slug for the prep-reminder cards, so they can link to the
     /// canonical `/r/{slug}` detail page. Missing ids fall back to the id.
     pub slugs: std::collections::HashMap<String, String>,
+    /// When true, the "Start cooking" button links to the recipe's original URL
+    /// (external) instead of the in-app cooking screen. See [`cook_is_external`].
+    pub cook_external: bool,
 }
 
 impl KitchenTemplate {
@@ -92,7 +95,34 @@ impl Default for KitchenTemplate {
             date: "".to_owned(),
             week_days: vec![],
             slugs: std::collections::HashMap::new(),
+            cook_external: false,
         }
+    }
+}
+
+/// Whether the "Start cooking" button should link straight to the recipe's
+/// original URL (opened externally) rather than into the in-app cooking screen.
+///
+/// True only when the recipe has no parsed steps AND its origin refuses framing —
+/// i.e. there is nothing to cook in-app. The embeddability check runs only for
+/// step-less recipes (and is cached per-domain), so recipes with steps never
+/// trigger a network call here.
+async fn cook_is_external(
+    app: &AppState,
+    slot_recipe: &imkitchen_core::recipe::query::user::UserView,
+    current_instruction: &Option<(usize, Instruction)>,
+) -> bool {
+    if current_instruction.is_some() {
+        return false;
+    }
+    match slot_recipe.origin.as_deref() {
+        Some(origin) => !app
+            .core
+            .recipe
+            .is_origin_embeddable(origin)
+            .await
+            .unwrap_or(false),
+        None => false,
     }
 }
 
@@ -410,6 +440,11 @@ pub async fn page(
         })
         .collect();
 
+    let cook_external = match slot_recipe.as_ref() {
+        Some(recipe) => cook_is_external(&app, recipe, &current_instruction).await,
+        None => false,
+    };
+
     let auth_cookie = imkitchen_web_shared::try_page_response!(sync:
         imkitchen_web_shared::auth::build_cookie(app.config.jwt, token.sub.to_owned(), token.acc.to_owned()),
         template
@@ -432,6 +467,7 @@ pub async fn page(
             date,
             week_days,
             slugs,
+            cook_external,
             ..Default::default()
         }),
     )
@@ -446,6 +482,7 @@ pub struct CookingTemplate {
     pub coming_instructions: Vec<(usize, String)>,
     pub current_instruction: Option<(usize, Instruction)>,
     pub date: String,
+    pub show_iframe: bool,
 }
 
 // Fragment version of CookingTemplate — same fields, but renders only the
@@ -458,6 +495,7 @@ pub struct CookingScreenTemplate {
     pub coming_instructions: Vec<(usize, String)>,
     pub current_instruction: Option<(usize, Instruction)>,
     pub date: String,
+    pub show_iframe: bool,
 }
 
 #[tracing::instrument(skip_all, fields(user = tracing::field::Empty))]
@@ -611,6 +649,16 @@ pub async fn update_slot_step_action(
         }
     };
 
+    let show_iframe = match slot_recipe.origin.as_deref() {
+        Some(origin) => app
+            .core
+            .recipe
+            .is_origin_embeddable(origin)
+            .await
+            .unwrap_or(false),
+        None => false,
+    };
+
     template
         .render(CookingScreenTemplate {
             slot_recipe,
@@ -618,6 +666,7 @@ pub async fn update_slot_step_action(
             coming_instructions,
             current_instruction,
             date,
+            show_iframe,
         })
         .into_response()
 }
@@ -631,6 +680,7 @@ pub struct KitchenDishTemplate {
     pub completed_instructions: Vec<(usize, String)>,
     pub coming_instructions: Vec<(usize, String)>,
     pub current_instruction: Option<(usize, Instruction)>,
+    pub cook_external: bool,
 }
 
 #[tracing::instrument(skip_all, fields(user = tracing::field::Empty))]
@@ -754,6 +804,8 @@ pub async fn select_dish(
         }
     };
 
+    let cook_external = cook_is_external(&app, &slot_recipe, &current_instruction).await;
+
     template
         .render(KitchenDishTemplate {
             slot,
@@ -762,6 +814,7 @@ pub async fn select_dish(
             coming_instructions,
             current_instruction,
             date,
+            cook_external,
         })
         .into_response()
 }
@@ -871,6 +924,25 @@ pub async fn cook_page(
         }
     };
 
+    let show_iframe = match slot_recipe.origin.as_deref() {
+        Some(origin) => app
+            .core
+            .recipe
+            .is_origin_embeddable(origin)
+            .await
+            .unwrap_or(false),
+        None => false,
+    };
+
+    // Imported recipe with no parsed steps whose origin refuses framing: there is
+    // nothing to show in-app, so send the user straight to the original instead of
+    // rendering a "Open Original Recipe" button they'd have to tap.
+    if !show_iframe && current_instruction.is_none() {
+        if let Some(origin) = slot_recipe.origin.as_deref() {
+            return Redirect::to(origin).into_response();
+        }
+    }
+
     template
         .render(CookingTemplate {
             slot_recipe,
@@ -878,6 +950,7 @@ pub async fn cook_page(
             coming_instructions,
             current_instruction,
             date,
+            show_iframe,
         })
         .into_response()
 }


### PR DESCRIPTION
## Summary

On the cooking screen, an imported recipe with an `origin` URL now shows the original page in an iframe **whenever the source site permits framing** — previously the iframe was only a fallback for recipes with no parsed steps, and it was rendered unconditionally (so frame-blocking sites showed a blank/broken frame).

New behavior for a recipe with an `origin`:
- **Origin allows framing** → embed the original page in the iframe.
- **Origin refuses framing** (`X-Frame-Options` / CSP `frame-ancestors`) → fall back to the parsed step UI if the recipe has steps, otherwise **redirect** to the original.
- The kitchen **"Start cooking"** button links straight to the source (new tab) for step-less, unframeable recipes, skipping the intermediate screen.
- A recipe with no `origin` is unchanged.

## Why server-side

Framing refusal **cannot be detected client-side** — a cross-origin iframe that was blocked is indistinguishable from one that loaded (the browser denies the parent any access to the child: `error`/`load`/timeout/`contentWindow` probes all fail or are ambiguous). So the source site's headers are read server-side.

## How it works

- The header check runs in a **background evento subscription** (`recipe-saga-embeddable`) that reacts to `Imported` / `BasicInformationChanged` events. It derives the domain, does one HTTP `GET`, inspects `X-Frame-Options` / CSP `frame-ancestors`, and caches the verdict per-domain in a new `origin_framing` table (migration **m0006**).
- Request handlers (`Module::is_origin_embeddable`) are a **pure cache read** — nothing on the request path blocks on the network.
- The cache is keyed by **domain** (framing policy is effectively site-wide), so each domain is fetched **at most once**; `.all()` backfills existing recipes on first deploy (serialized + deduped → no request burst / IP-block risk). Import stays fully network-free.
- Any network failure (timeout, refused, blocked IP, DNS/TLS) → treated as not embeddable → graceful fallback.

**Trade-off:** eventual consistency — a brand-new import reads as not-embeddable for the brief window until the saga processes its event (normally well before the cooking screen is opened).

## Changes

- `crates/db`: new `origin_framing(domain PK, embeddable, checked_at)` table + `m0006` migration.
- `crates/core`: `recipe/query/embeddable.rs` (cache read + header-check helpers) and `recipe/saga/embeddable.rs` (the background subscription); adds `reqwest` (rustls-tls).
- `web/kitchen`: `cook_page` / `update_slot_step_action` pass a `show_iframe` flag; `page` / `select_dish` compute a `cook_external` flag for the Start button; `cook_page` redirects step-less unframeable recipes to the origin.
- `src/cli/server.rs`: registers/【shuts down】 the new subscription.
- Templates: `cooking-screen.html` (iframe/steps/link branching) and `kitchen-dish.html` (smart Start button).

## Verification

- Workspace builds clean, no warnings; migration applied (`origin_framing` created).
- Header parsing verified against real sites: `planetevegan.com` (`X-Frame-Options: SAMEORIGIN`) → not embeddable; `tatiemaryse.com` → embeddable.
- Confirmed the background saga populates the cache with **zero request traffic** (table grew across server boots), and since `is_origin_embeddable` no longer writes, the saga is the sole writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)