### PR TITLE
fix(recipe): blur placeholder for lazy-loaded thumbnails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "base64",
  "bitcode",
  "evento",
  "image",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ thiserror.workspace = true
 argon2.workspace = true
 validator = { workspace = true }
 sqlx = { workspace = true }
+base64 = { workspace = true }
 image = { workspace = true }
 webp = { workspace = true }
 strum.workspace = true

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -1,9 +1,11 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
 use evento::{
     Cursor, Executor, Projection, Snapshot,
     cursor::{Args, ReadResult},
     metadata::Event,
     sql::Reader,
 };
+use image::imageops::FilterType;
 use imkitchen_db::mealplan_recipe::MealPlanRecipe;
 use imkitchen_db::recipe_user::{RecipeUser, RecipeUserFts};
 use imkitchen_types::recipe::{
@@ -17,6 +19,7 @@ use sea_query_sqlx::SqlxBinder;
 use serde::Deserialize;
 use sqlx::{SqlitePool, prelude::FromRow};
 use strum::{Display, EnumString};
+use webp::Encoder;
 
 #[derive(Default, Debug, Deserialize, EnumString, Display, Clone)]
 pub enum SortBy {
@@ -48,6 +51,7 @@ pub struct UserView {
     pub difficulty_score: u16,
     pub created_at: u64,
     pub thumbnail_version: Option<String>,
+    pub blur_placeholder: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, FromRow, Cursor)]
@@ -71,6 +75,7 @@ pub struct UserViewList {
     #[cursor(RecipeUser::CreatedAt, 2)]
     pub created_at: u64,
     pub thumbnail_version: Option<String>,
+    pub blur_placeholder: Option<String>,
 }
 
 pub struct RecipesQuery {
@@ -109,6 +114,7 @@ impl<E: Executor> crate::recipe::Module<E> {
                 RecipeUser::DifficultyScore,
                 RecipeUser::CreatedAt,
                 RecipeUser::ThumbnailVersion,
+                RecipeUser::BlurPlaceholder,
             ])
             .from(RecipeUser::Table)
             .to_owned();
@@ -374,6 +380,7 @@ async fn find_user(pool: &SqlitePool, id: impl Into<String>) -> anyhow::Result<O
             RecipeUser::DifficultyScore,
             RecipeUser::CreatedAt,
             RecipeUser::ThumbnailVersion,
+            RecipeUser::BlurPlaceholder,
         ])
         .from(RecipeUser::Table)
         .and_where(Expr::col(RecipeUser::Id).eq(id.into()))
@@ -520,6 +527,7 @@ impl<E: Executor> Snapshot<E> for UserView {
                 RecipeUser::DifficultyScore,
                 RecipeUser::CreatedAt,
                 RecipeUser::ThumbnailVersion,
+                RecipeUser::BlurPlaceholder,
             ])
             .values([
                 self.id.to_owned().into(),
@@ -543,6 +551,7 @@ impl<E: Executor> Snapshot<E> for UserView {
                 difficulty_score.into(),
                 self.created_at.into(),
                 self.thumbnail_version.to_owned().into(),
+                self.blur_placeholder.to_owned().into(),
             ])?
             .on_conflict(
                 OnConflict::column(RecipeUser::Id)
@@ -567,6 +576,7 @@ impl<E: Executor> Snapshot<E> for UserView {
                         RecipeUser::DifficultyScore,
                         RecipeUser::CreatedAt,
                         RecipeUser::ThumbnailVersion,
+                        RecipeUser::BlurPlaceholder,
                     ])
                     .to_owned(),
             )
@@ -730,5 +740,33 @@ async fn handle_thumbnail_resized(
 ) -> anyhow::Result<()> {
     data.thumbnail_version = Some(event.id.to_string());
 
+    // Derive a tiny blurred base64 placeholder (LQIP) from the mobile variant only,
+    // so it is generated once per upload rather than once per device.
+    if event.data.device == "mobile" {
+        data.blur_placeholder = build_blur_placeholder(&event.data.data);
+    }
+
     Ok(())
+}
+
+/// Downscale the given WebP thumbnail to a tiny blurred base64 data URL used as a
+/// low-quality image placeholder while the full image lazy-loads. Returns `None`
+/// (falling back to the gradient) if the bytes cannot be decoded.
+fn build_blur_placeholder(bytes: &[u8]) -> Option<String> {
+    let img = match image::load_from_memory(bytes) {
+        Ok(img) => img,
+        Err(err) => {
+            tracing::warn!(error = ?err, "recipe-query.handle_thumbnail_resized.load_from_memory");
+            return None;
+        }
+    };
+
+    let tiny = img.resize(32, u32::MAX, FilterType::Triangle).blur(1.0);
+    let rgba = tiny.to_rgba8();
+    let encoded = Encoder::from_rgba(rgba.as_raw(), rgba.width(), rgba.height()).encode(40.0);
+
+    Some(format!(
+        "data:image/webp;base64,{}",
+        STANDARD.encode(&*encoded)
+    ))
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod m0003;
 pub(crate) mod m0004;
 pub(crate) mod m0005;
 pub(crate) mod m0006;
+pub(crate) mod m0007;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
@@ -40,6 +41,7 @@ where
     m0004::Migration: sqlx_migrator::Migration<DB>,
     m0005::Migration: sqlx_migrator::Migration<DB>,
     m0006::Migration: sqlx_migrator::Migration<DB>,
+    m0007::Migration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = evento::sql_migrator::new::<DB>()?;
     migrator.add_migrations(vec![
@@ -49,6 +51,7 @@ where
         Box::new(m0004::Migration),
         Box::new(m0005::Migration),
         Box::new(m0006::Migration),
+        Box::new(m0007::Migration),
     ])?;
 
     Ok(migrator)

--- a/crates/db/src/m0007/mod.rs
+++ b/crates/db/src/m0007/mod.rs
@@ -1,0 +1,11 @@
+use sqlx_migrator::vec_box;
+
+pub struct Migration;
+
+sqlx_migrator::sqlite_migration!(
+    Migration,
+    "imkitchen",
+    "m0007",
+    vec_box![super::m0006::Migration],
+    vec_box![crate::recipe_user::m0007::AddBlurPlaceholder]
+);

--- a/crates/db/src/recipe_user.rs
+++ b/crates/db/src/recipe_user.rs
@@ -26,6 +26,7 @@ pub enum RecipeUser {
     UpdatedAt,
     ThumbnailVersion,
     DifficultyScore,
+    BlurPlaceholder,
 }
 
 #[derive(Iden, Clone)]
@@ -647,6 +648,45 @@ pub(crate) mod m0005 {
                 .execute(&mut *connection)
                 .await?;
             sqlx::query("ALTER TABLE recipe_user DROP COLUMN slug")
+                .execute(connection)
+                .await
+                .ok();
+
+            Ok(())
+        }
+    }
+}
+
+pub(crate) mod m0007 {
+    pub struct AddBlurPlaceholder;
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for AddBlurPlaceholder {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            sqlx::query("ALTER TABLE recipe_user ADD COLUMN blur_placeholder TEXT")
+                .execute(&mut *connection)
+                .await
+                .ok();
+
+            // The blur placeholder is derived during projection from the mobile
+            // thumbnail variant, so reset the subscription to replay every
+            // ThumbnailResized event and backfill existing recipes. The column is
+            // nullable, so no truncate is required.
+            sqlx::query("UPDATE subscriber SET cursor = NULL WHERE key = 'recipe-query'")
+                .execute(connection)
+                .await?;
+
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            sqlx::query("ALTER TABLE recipe_user DROP COLUMN blur_placeholder")
                 .execute(connection)
                 .await
                 .ok();

--- a/templates/recipes-detail.html
+++ b/templates/recipes-detail.html
@@ -49,6 +49,9 @@
 
 {# ── Lazy thumbnail macros (preserved from previous template) ── #}
 {% macro lazy_thumbnail(recipe, version) %}
+{% if let Some(blur) = recipe.blur_placeholder %}
+<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
+{% endif %}
 <picture>
   <source data-media="(max-width: 480px)"
     data-srcset="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" />
@@ -62,6 +65,9 @@
 {% endmacro %}
 
 {% macro lazy_card_thumbnail(recipe, version) %}
+{% if let Some(blur) = recipe.blur_placeholder %}
+<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
+{% endif %}
 <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
   data-src="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" alt="{{ recipe.name }}"
   class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 [&.loaded]:opacity-100"

--- a/templates/recipes-index.html
+++ b/templates/recipes-index.html
@@ -2,6 +2,9 @@
 {% block title %}{{ "Recipes"|t }} - imkitchen{% endblock %}
 
 {% macro lazy_thumbnail(recipe, version) %}
+{% if let Some(blur) = recipe.blur_placeholder %}
+<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
+{% endif %}
 <picture>
   <source data-media="(max-width: 480px)"
     data-srcset="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" />


### PR DESCRIPTION
## Context

On the recipe list and detail pages, thumbnails lazy-load. Until the real WebP arrives, the `<img>` is `opacity-0` and only the container's flat gradient shows — users see an empty colored box that then pops to the photo.

This adds a small blurred base64 preview (LQIP) shown immediately, carried with the recipe data, that the sharp image fades in over.

## How it works

The placeholder is derived **on the read side** from the existing `mobile` thumbnail variant — decode → resize to 32px → blur → re-encode WebP (q40) → base64 data URL — and stored in a new nullable `recipe_user.blur_placeholder` column so it travels with the list/detail query results.

Doing it in the read projection (not the command side) means **no new domain event**, and the `m0007` migration resets the `recipe-query` subscription cursor to replay `ThumbnailResized` events and **auto-backfill existing recipes**.

## Changes

- **DB** (`crates/db`): `BlurPlaceholder` Iden + new `m0007::AddBlurPlaceholder` migration (adds nullable column, resets `recipe-query` cursor); registered `m0007` in `lib.rs`.
- **Read model** (`crates/core/src/recipe/query/user.rs`): new `blur_placeholder` field on `UserView`/`UserViewList`; generation in `handle_thumbnail_resized` (mobile variant only; decode failures warn and fall back to `None`/gradient); wired into snapshot insert and both SELECT lists. Added `base64` dep.
- **Templates**: blurred CSS background `<div>` (`bg-cover scale-110 blur-lg`) behind the fading image in the shared lazy macros of `recipes-index.html` and `recipes-detail.html`, shown only when a placeholder is present.

## Verification

- `cargo build` passes (Askama validates template field references at compile time).
- `cargo test -p imkitchen-core` green.
- Manual: run app (migration backfills on startup), load recipe list with throttled network → soft blurred preview shows immediately with the sharp image fading in; recipes without a thumbnail keep the emoji/gradient fallback. Upload a new thumbnail → fresh placeholder generated after resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)