### PR TITLE
feat(settings): send password reset link from account settings

### DIFF
--- a/templates/settings-account.html
+++ b/templates/settings-account.html
@@ -3,6 +3,33 @@
 
 {% block settings_content %}
 
+{# ── Password ─────────────────────────────────────────────────── #}
+<section>
+  <div class="text-[11px] font-mono font-semibold tracking-widest uppercase text-ink-3 mb-2 px-1">
+    {{ "Password"|t }}
+  </div>
+  <div class="bg-paper rounded-2xl border border-line-2 shadow-sm overflow-hidden">
+    <form method="post" action="/settings/account" ts-req="" ts-swap="skip"
+      class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 px-4 py-4 sm:px-5">
+      <div class="flex items-center gap-3 sm:gap-4 min-w-0 flex-1">
+        <div class="w-10 h-10 rounded-xl bg-cream-2 text-ink-2 flex items-center justify-center shrink-0">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.7" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/>
+          </svg>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="text-sm font-semibold text-ink">{{ "Reset password"|t }}</div>
+          <div class="text-[12px] text-ink-3 mt-0.5">{{ "We'll email you a secure link to set a new password. All devices will be signed out."|t }}</div>
+        </div>
+      </div>
+      <button type="submit"
+        class="inline-flex items-center justify-center w-full sm:w-auto px-4 h-10 bg-ink text-cream font-semibold rounded-xl text-sm hover:opacity-90 shadow-sm transition shrink-0">
+        {{ "Send reset link"|t }}
+      </button>
+    </form>
+  </div>
+</section>
+
 {# ── Sessions ─────────────────────────────────────────────────── #}
 <section>
   <div class="text-[11px] font-mono font-semibold tracking-widest uppercase text-ink-3 mb-2 px-1">

--- a/web/settings/src/routes/account.rs
+++ b/web/settings/src/routes/account.rs
@@ -1,17 +1,16 @@
-// use axum::Form;
 use axum::extract::State;
 use axum::response::IntoResponse;
-// use serde::Deserialize;
 
+use imkitchen_identity::password::RequestInput;
 use imkitchen_web_shared::AppState;
 use imkitchen_web_shared::auth::AuthUser;
 use imkitchen_web_shared::template::Template;
+use imkitchen_web_shared::template::ToastSuccessTemplate;
 use imkitchen_web_shared::template::filters;
 
 #[derive(askama::Template)]
 #[template(path = "settings-account.html")]
 pub struct SecurityTemplate {
-    // pub error_message: Option<String>,
     pub current_path: String,
     pub settings_path: String,
     pub user: AuthUser,
@@ -19,22 +18,31 @@ pub struct SecurityTemplate {
 
 pub async fn page(template: Template, user: AuthUser) -> impl IntoResponse {
     template.render(SecurityTemplate {
-        // error_message: None,
         current_path: "settings".to_owned(),
         settings_path: "account".to_owned(),
         user,
     })
 }
-//
-// #[derive(Deserialize)]
-// pub struct ActionInput {
-//     pub email: String,
-// }
 
 pub async fn action(
-    _template: Template,
-    State(_app): State<AppState>,
-    // Form(input): Form<ActionInput>,
+    template: Template,
+    State(app): State<AppState>,
+    user: AuthUser,
 ) -> impl IntoResponse {
-    ""
+    imkitchen_web_shared::try_response!(
+        app.identity.password.request(RequestInput {
+            email: user.email.to_owned(),
+            lang: template.preferred_language_iso.to_owned(),
+            host: app.config.server.url.to_owned(),
+        }),
+        template
+    );
+
+    template
+        .render(ToastSuccessTemplate {
+            original: None,
+            message: "We've emailed you a secure link to reset your password.",
+            description: None,
+        })
+        .into_response()
 }


### PR DESCRIPTION
## Context

Previously, a signed-in user could only reset their password by logging out, going to the login page, clicking "Forgot password", and entering their email. Poor UX for someone already authenticated.

## Change

Adds a **Password** section to `Settings → Account` with a **Send reset link** button. Clicking it emails the logged-in user the same secure, tokenized reset link produced by the public forgot-password page. Completing the reset logs the user out of every device (existing built-in behavior of `handle_reset_completed`).

- `web/settings/src/routes/account.rs` — the previously-empty `POST /settings/account` handler now calls the existing `app.identity.password.request(...)` with the user's email/lang/host and returns a success toast. Removed dead commented scaffolding.
- `templates/settings-account.html` — new Password section/form following the existing `ts-req="" ts-swap="skip"` toast convention.

No new domain command, route, or event — it reuses the entire existing reset pipeline (token TTL, single-use, email delivery, session invalidation).

## Verification

- `cargo clippy -p imkitchen-web-settings` passes clean.
- Manual: log in → Settings → Account → **Send reset link** → success toast + reset email → open link → set new password → all sessions signed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)