### PR TITLE
fix(admin): stop premium badge smearing across users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1695,7 +1695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "evento"
-version = "2.0.0-alpha.23"
+version = "2.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c62a65988882b84f5cd9686a67095c5bfd99532752eb448d18d04c44c018e0"
+checksum = "ac102a7870b6af26fd36c7c765d18e73b6077cb59937304876c875bc4309f13a"
 dependencies = [
  "evento-core",
  "evento-sql",
@@ -1733,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "evento-core"
-version = "2.0.0-alpha.23"
+version = "2.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df46dcbb5661266c31075449a6f1f3eefe7e789ad3ee76bc94f6757d695ad596"
+checksum = "edbbb1b2437dd119dce3c9042775c797c2f8e0af9aa442f5ccee5900f8d03cc6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "evento-macro"
-version = "2.0.0-alpha.23"
+version = "2.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f036932ae47c1fc5710a5ed2bdea4a4119bb4a8caecba0062e6f548b4df41d"
+checksum = "2c190bfdf69081e441ac02f939efb43146aa4367c4df3186659226f7193a045d"
 dependencies = [
  "convert_case 0.11.0",
  "quote",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql"
-version = "2.0.0-alpha.23"
+version = "2.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badd63715654cdd067613dd9d439a90e5d61685fa21863159d98dbb90ff3bc3f"
+checksum = "5b03632b291b4a37acddcaa99d1258e19ae6ee95824e5fc60b095ce676c84bde"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "evento-sql-migrator"
-version = "2.0.0-alpha.23"
+version = "2.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc02b01a00f8a5b4d90a144c9ddce1c32e5875c6b597826d7c5186921f777850"
+checksum = "8c6033921912ba0de46b9fe40a9fde7c3c0f5de71e4f831ab266ef3c2078aa67"
 dependencies = [
  "async-trait",
  "evento-sql",
@@ -2956,7 +2956,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3508,7 +3508,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5468,7 +5468,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5970,7 +5970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6326,7 +6326,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7239,7 +7239,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ askama = "0.16"
 world-tax = "0.5"
 sqlx = { version = "0.9", default-features = false, features = ["migrate", "json", "derive", "runtime-tokio", "sqlite"] }
 sqlx_migrator = { version = "0.19", features = ["sqlite"] }
-evento = { version = "2.0.0-alpha.21", features = ["sqlite", "rw"] }
+evento = { version = "2.0.0-alpha.24", features = ["sqlite", "rw"] }
 argon2 = { version = "0.5", features = ["std"] }
 jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 lettre = { version = "0.11", features = ["rustls-tls", "builder"] }

--- a/crates/db/src/m0007/mod.rs
+++ b/crates/db/src/m0007/mod.rs
@@ -7,5 +7,8 @@ sqlx_migrator::sqlite_migration!(
     "imkitchen",
     "m0007",
     vec_box![super::m0006::Migration],
-    vec_box![crate::recipe_user::m0007::AddBlurPlaceholder]
+    vec_box![
+        crate::recipe_user::m0007::AddBlurPlaceholder,
+        crate::user_admin::m0007::ResetPremiumSmear,
+    ]
 );

--- a/crates/db/src/user_admin.rs
+++ b/crates/db/src/user_admin.rs
@@ -269,3 +269,45 @@ DROP TABLE user_admin_fts;
         }
     }
 }
+
+pub(crate) mod m0007 {
+    pub struct ResetPremiumSmear;
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for ResetPremiumSmear {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // Before evento 2.0.0-alpha.24, the background `user-query` projection read the
+            // co-keyed `Subscription` events (`LifePremiumToggled` / `StripePaymentIntentSucceeded`)
+            // unscoped (`by_type`) and smeared one user's premium expiry across every admin row.
+            // Delete the rows rather than resetting the per-row `cursor`. An empty cursor is not a
+            // valid encoding (reload fails to decode it), and a surviving row would carry its
+            // smeared `subscription_expire_at` forward via `snapshot.unwrap_or_default()` — a
+            // no-event victim has nothing in the replay to reset the field. Deleting makes each
+            // reload start from `Default` (expiry 0) and re-apply only that user's own (now
+            // id-scoped) subscription events. The `user_admin_delete` trigger clears the FTS rows;
+            // the insert trigger refills them as the projection rebuilds.
+            sqlx::query("DELETE FROM user_admin")
+                .execute(&mut *connection)
+                .await?;
+
+            // Rewind the projection's subscription so the worker replays the whole stream and
+            // rebuilds `user_admin` on next start (same mechanism as the m0007 recipe backfill).
+            sqlx::query("UPDATE subscriber SET cursor = NULL WHERE key = 'user-query'")
+                .execute(connection)
+                .await?;
+
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            _connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // One-way data repair: the projection rebuilds itself on replay, nothing to revert.
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The admin **Users** list showed newly registered (and other non-premium) users with the ✨ Premium badge, even though the regular app correctly treated them as non-premium.

Root cause: `AdminView` (`user_admin`) is built by a background `.subscription("user-query").all()` worker, and its `Projection::new::<User>()` also handles the **co-keyed** `Subscription` events (`LifePremiumToggled` / `StripePaymentIntentSucceeded`). Before evento `alpha.24`, the subscription path rebuilt each row with an empty aggregator map, so those secondary handlers read **every** premium event in the store (`by_type`) and smeared the most recent expiry onto every row. The lazy, id-scoped `find_login` path (`user_login`) was unaffected — hence the bug was admin-only.

Confirmed on prod/local data: several `user_admin` rows carried an identical far-future `subscription_expire_at` (`add_months(now, 120)` from one real toggle), and at least one premium row owned **no** premium event of its own.

## Fix

- Bump `evento` `2.0.0-alpha.21` → **`2.0.0-alpha.24`**, which co-keys secondary aggregates in subscription mode (timayz/evento#212) — the worker now scopes `Subscription` events to the event's own aggregate id, matching the lazy `load` path.
- Extend the **not-yet-released** `m0007` migration with `user_admin::m0007::ResetPremiumSmear` to repair existing data:
  ```sql
  DELETE FROM user_admin;
  UPDATE subscriber SET cursor = NULL WHERE key = 'user-query';
  ```
  `DELETE` (rather than a per-row `cursor` reset) because an empty cursor is an invalid encoding and a surviving row would carry its smeared `subscription_expire_at` forward via `snapshot.unwrap_or_default()`. Deleting makes each reload start from `Default` (expiry `0`) and re-apply only the user's own id-scoped events; the `user_admin_delete` trigger keeps the FTS table in sync, the insert trigger refills it on rebuild.

## Verification

- `cargo build --workspace` clean on alpha.24 (no API drift).
- Migration executed against a local `imkitchen.db` that reproduced the smear: `user_admin` → 0 rows, `user_admin_fts` → 0 (trigger cascade), `user-query` cursor → NULL. On replay the 3 event-owning users regain premium; the no-event victim rebuilds at `0`.

## Deploy notes

Prod is at m0006, so the init container runs m0007 (blur backfill + premium reset) once, then the alpha.24 app replays and rebuilds `user_admin` correctly. No projection code change required — co-keying is automatic after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)