### PR TITLE
feat(admin): allow changing a user's email address

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod m0004;
 pub(crate) mod m0005;
 pub(crate) mod m0006;
 pub(crate) mod m0007;
+pub(crate) mod m0008;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
@@ -42,6 +43,7 @@ where
     m0005::Migration: sqlx_migrator::Migration<DB>,
     m0006::Migration: sqlx_migrator::Migration<DB>,
     m0007::Migration: sqlx_migrator::Migration<DB>,
+    m0008::Migration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = evento::sql_migrator::new::<DB>()?;
     migrator.add_migrations(vec![
@@ -52,6 +54,7 @@ where
         Box::new(m0005::Migration),
         Box::new(m0006::Migration),
         Box::new(m0007::Migration),
+        Box::new(m0008::Migration),
     ])?;
 
     Ok(migrator)

--- a/crates/db/src/m0008/mod.rs
+++ b/crates/db/src/m0008/mod.rs
@@ -1,0 +1,11 @@
+use sqlx_migrator::vec_box;
+
+pub struct Migration;
+
+sqlx_migrator::sqlite_migration!(
+    Migration,
+    "imkitchen",
+    "m0008",
+    vec_box![super::m0007::Migration],
+    vec_box![crate::user_admin::m0008::SyncEmailFts]
+);

--- a/crates/db/src/user_admin.rs
+++ b/crates/db/src/user_admin.rs
@@ -311,3 +311,53 @@ pub(crate) mod m0007 {
         }
     }
 }
+
+pub(crate) mod m0008 {
+    pub struct SyncEmailFts;
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for SyncEmailFts {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // The original `user_admin_update` trigger only re-synced `username` to the FTS index,
+            // so an admin-changed email stayed searchable only by its old value. Recreate the
+            // trigger to also propagate `email`.
+            sqlx::query(
+                r#"
+DROP TRIGGER user_admin_update;
+
+CREATE TRIGGER user_admin_update AFTER
+UPDATE on user_admin BEGIN
+UPDATE user_admin_fts SET email = new.email, username = COALESCE(new.username, '')
+WHERE user_admin_fts = new.id; END;
+            "#,
+            )
+            .execute(connection)
+            .await?;
+
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            sqlx::query(
+                r#"
+DROP TRIGGER user_admin_update;
+
+CREATE TRIGGER user_admin_update AFTER
+UPDATE on user_admin BEGIN
+UPDATE user_admin_fts SET username = COALESCE(new.username, '')
+WHERE user_admin_fts = new.id; END;
+            "#,
+            )
+            .execute(connection)
+            .await?;
+
+            Ok(())
+        }
+    }
+}

--- a/crates/identity/src/password/reset.rs
+++ b/crates/identity/src/password/reset.rs
@@ -43,6 +43,7 @@ impl<E: Executor> super::Module<E> {
             &self.write_db,
             repository::UpdateInput {
                 id: password.user_id.to_owned(),
+                email: None,
                 username: None,
                 password: Some(password_hash),
                 role: None,

--- a/crates/identity/src/query/admin.rs
+++ b/crates/identity/src/query/admin.rs
@@ -13,7 +13,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use strum::{AsRefStr, Display, EnumString, VariantArray};
 
 use crate::types::user::{
-    Activated, MadeAdmin, Registered, Role, RoleChanged, State, Suspended, User, UsernameChanged,
+    Activated, EmailChanged, MadeAdmin, Registered, Role, RoleChanged, State, Suspended, User,
+    UsernameChanged,
 };
 use imkitchen_billing::types::subscription::{
     LifePremiumToggled, StripePaymentIntentSucceeded, Subscription,
@@ -224,6 +225,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, AdminView> {
         .handler(handle_life_premium_toggled())
         .handler(handle_payment_intent_succeeded())
         .handler(handle_username_changed())
+        .handler(handle_email_changed())
 }
 
 impl<E: Executor> Snapshot<E> for AdminView {
@@ -367,6 +369,16 @@ async fn handle_username_changed(
     data: &mut AdminView,
 ) -> anyhow::Result<()> {
     data.username = Some(event.data.value);
+
+    Ok(())
+}
+
+#[evento::handler]
+async fn handle_email_changed(
+    event: Event<EmailChanged>,
+    data: &mut AdminView,
+) -> anyhow::Result<()> {
+    data.email = event.data.value;
 
     Ok(())
 }

--- a/crates/identity/src/query/login.rs
+++ b/crates/identity/src/query/login.rs
@@ -7,8 +7,8 @@ use sqlx::{SqlitePool, prelude::FromRow};
 
 use crate::types::password::ResetCompleted;
 use crate::types::user::{
-    Activated, LoggedIn, Logout, MadeAdmin, Registered, Role, RoleChanged, State, Suspended, User,
-    UsernameChanged,
+    Activated, EmailChanged, LoggedIn, Logout, MadeAdmin, Registered, Role, RoleChanged, State,
+    Suspended, User, UsernameChanged,
 };
 use imkitchen_billing::types::subscription::{
     LifePremiumToggled, StripePaymentIntentSucceeded, Subscription,
@@ -94,6 +94,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, LoginView> {
         .handler(handle_role_changed())
         .handler(handle_reset_completed())
         .handler(handle_username_changed())
+        .handler(handle_email_changed())
         .handler(handle_life_premium_toggled())
         .handler(handle_payment_intent_succeeded())
 }
@@ -194,6 +195,20 @@ async fn handle_username_changed(
 
     for login in data.logins.iter_mut() {
         login.username = Some(event.data.value.to_owned());
+    }
+
+    Ok(())
+}
+
+#[evento::handler]
+async fn handle_email_changed(
+    event: Event<EmailChanged>,
+    data: &mut LoginView,
+) -> anyhow::Result<()> {
+    data.email = event.data.value.to_owned();
+
+    for login in data.logins.iter_mut() {
+        login.email = event.data.value.to_owned();
     }
 
     Ok(())

--- a/crates/identity/src/repository.rs
+++ b/crates/identity/src/repository.rs
@@ -90,6 +90,7 @@ pub(super) async fn create(
 
 pub struct UpdateInput {
     pub id: String,
+    pub email: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
     pub role: Option<Role>,
@@ -101,6 +102,10 @@ pub async fn update(pool: &SqlitePool, input: UpdateInput) -> imkitchen_core::Re
         .table(User::Table)
         .and_where(Expr::col(User::Id).eq(input.id))
         .to_owned();
+
+    if let Some(email) = input.email {
+        statement.value(User::Email, email);
+    }
 
     if let Some(username) = input.username {
         statement.value(User::Username, username);

--- a/crates/identity/src/root/change_email.rs
+++ b/crates/identity/src/root/change_email.rs
@@ -1,0 +1,70 @@
+use crate::types::user::EmailChanged;
+use evento::{Executor, ProjectionAggregate};
+use validator::Validate;
+
+use crate::root::repository;
+
+#[derive(Validate)]
+pub struct ChangeEmailInput {
+    #[validate(email)]
+    pub email: String,
+}
+
+impl<E: Executor> super::Module<E> {
+    pub async fn change_email(
+        &self,
+        id: impl Into<String>,
+        email: String,
+        request_by: impl Into<String>,
+    ) -> imkitchen_core::Result<()> {
+        let input = ChangeEmailInput { email };
+        input.validate()?;
+
+        let id = id.into();
+
+        let Some(user) =
+            repository::find(&self.read_db, repository::FindType::Id(id.to_owned())).await?
+        else {
+            imkitchen_core::not_found!("user not found");
+        };
+
+        if user.email.eq_ignore_ascii_case(&input.email) {
+            return Ok(());
+        }
+
+        if let Some(existing) = repository::find(
+            &self.read_db,
+            repository::FindType::Email(input.email.to_owned()),
+        )
+        .await?
+            && existing.id != user.id
+        {
+            imkitchen_core::user!("Email already exists");
+        }
+
+        repository::update(
+            &self.write_db,
+            repository::UpdateInput {
+                id: user.id.to_owned(),
+                email: Some(input.email.to_owned()),
+                username: None,
+                password: None,
+                role: None,
+                state: None,
+            },
+        )
+        .await?;
+
+        let Some(user) = self.load(&user.id).await? else {
+            imkitchen_core::server!("user in change_email");
+        };
+
+        user.write()?
+            .event(&EmailChanged { value: input.email })
+            .requested_by(request_by)
+            .commit(&self.executor)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/identity/src/root/mod.rs
+++ b/crates/identity/src/root/mod.rs
@@ -1,6 +1,6 @@
 use crate::types::user::{
-    self, Activated, LoggedIn, Logout, MadeAdmin, Registered, Role, RoleChanged, State, Suspended,
-    UsernameChanged,
+    self, Activated, EmailChanged, LoggedIn, Logout, MadeAdmin, Registered, Role, RoleChanged,
+    State, Suspended, UsernameChanged,
 };
 use bitcode::{Decode, Encode};
 use evento::{Executor, Projection, ProjectionAggregate, metadata::Event};
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use crate::repository::{self};
 
 mod activate;
+mod change_email;
 mod change_role;
 mod login;
 mod made_admin;
@@ -113,6 +114,7 @@ pub fn create_projection<E: Executor>() -> Projection<E, User> {
         .skip::<LoggedIn>()
         .skip::<Logout>()
         .skip::<UsernameChanged>()
+        .skip::<EmailChanged>()
         .strict()
 }
 

--- a/crates/identity/src/root/set_username.rs
+++ b/crates/identity/src/root/set_username.rs
@@ -41,6 +41,7 @@ impl<E: Executor> super::Module<E> {
             &self.write_db,
             repository::UpdateInput {
                 id: user.id.to_owned(),
+                email: None,
                 username: Some(input.username.to_owned()),
                 password: None,
                 role: None,

--- a/crates/identity/src/types/user.rs
+++ b/crates/identity/src/types/user.rs
@@ -57,6 +57,9 @@ pub enum User {
     UsernameChanged {
         value: String,
     },
+    EmailChanged {
+        value: String,
+    },
     Logout {
         access_id: String,
     },

--- a/crates/identity/tests/change_email.rs
+++ b/crates/identity/tests/change_email.rs
@@ -1,0 +1,108 @@
+use temp_dir::TempDir;
+
+mod helpers;
+
+#[tokio::test]
+async fn test_change_email() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let path = dir.child("db.sqlite3");
+    let state = helpers::setup_test_state(path).await?;
+    let cmd = imkitchen_identity::Module::new(state);
+    let user_id = helpers::create_user(&cmd, "john.doe").await?;
+
+    assert_eq!(
+        cmd.find_email(&user_id).await?.as_deref(),
+        Some("john.doe@imkitchen.localhost")
+    );
+
+    cmd.change_email(
+        &user_id,
+        "new.email@imkitchen.localhost".to_owned(),
+        "admin",
+    )
+    .await?;
+
+    assert_eq!(
+        cmd.find_email(&user_id).await?.as_deref(),
+        Some("new.email@imkitchen.localhost")
+    );
+
+    // The old email no longer resolves to an account; the new one does.
+    assert!(
+        cmd.find_account("john.doe@imkitchen.localhost")
+            .await?
+            .is_none()
+    );
+    assert!(
+        cmd.find_account("new.email@imkitchen.localhost")
+            .await?
+            .is_some()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_change_email_same_is_noop() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let path = dir.child("db.sqlite3");
+    let state = helpers::setup_test_state(path).await?;
+    let cmd = imkitchen_identity::Module::new(state);
+    let user_id = helpers::create_user(&cmd, "john.doe").await?;
+
+    cmd.change_email(&user_id, "john.doe@imkitchen.localhost".to_owned(), "admin")
+        .await?;
+
+    assert_eq!(
+        cmd.find_email(&user_id).await?.as_deref(),
+        Some("john.doe@imkitchen.localhost")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_change_email_rejects_duplicate() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let path = dir.child("db.sqlite3");
+    let state = helpers::setup_test_state(path).await?;
+    let cmd = imkitchen_identity::Module::new(state);
+    let ids = helpers::create_users(&cmd, vec!["john.doe", "jane.doe"]).await?;
+    let john = ids.first().unwrap();
+
+    let err = cmd
+        .change_email(john, "jane.doe@imkitchen.localhost".to_owned(), "admin")
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Email already exists"));
+
+    // John's email is unchanged.
+    assert_eq!(
+        cmd.find_email(john).await?.as_deref(),
+        Some("john.doe@imkitchen.localhost")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_change_email_rejects_invalid_format() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let path = dir.child("db.sqlite3");
+    let state = helpers::setup_test_state(path).await?;
+    let cmd = imkitchen_identity::Module::new(state);
+    let user_id = helpers::create_user(&cmd, "john.doe").await?;
+
+    assert!(
+        cmd.change_email(&user_id, "not-an-email".to_owned(), "admin")
+            .await
+            .is_err()
+    );
+
+    assert_eq!(
+        cmd.find_email(&user_id).await?.as_deref(),
+        Some("john.doe@imkitchen.localhost")
+    );
+
+    Ok(())
+}

--- a/templates/partials/admin-user-edit-modal.html
+++ b/templates/partials/admin-user-edit-modal.html
@@ -1,16 +1,20 @@
 <div id="admin-user-edit-modal" class="fixed inset-0 bg-black/50 z-40 flex items-center justify-center p-4">
   <div class="bg-paper rounded-xl shadow-md max-w-md w-full">
-    <form ts-req="/admin/users/{{ user.id }}/role" ts-req-method="POST"
+    <form ts-req="/admin/users/{{ user.id }}" ts-req-method="POST"
       ts-req-selector="#user-{{ user.id }}" ts-target="#user-{{ user.id }}"
       ts-req-after="remove #admin-user-edit-modal">
       <div class="p-6 border-b">
         <h3 class="text-lg font-bold">Edit User</h3>
-        <p class="text-sm text-ink-2 mt-1">{{ user.email }}</p>
         {% if let Some(full_name) = user.full_name.as_deref() %}
         <p class="text-xs text-ink-3 mt-1">{{ full_name }}</p>
         {% endif %}
       </div>
       <div class="p-6 space-y-4">
+        <div>
+          <label class="block text-sm font-semibold text-ink-2 mb-2">Email</label>
+          <input name="email" type="email" value="{{ user.email }}" required
+            class="w-full px-4 py-2 border border-line rounded-xl focus:ring-2 focus:ring-primary-500" />
+        </div>
         <div>
           <label class="block text-sm font-semibold text-ink-2 mb-2">Role</label>
           <select name="role"

--- a/web/admin/src/lib.rs
+++ b/web/admin/src/lib.rs
@@ -17,7 +17,7 @@ pub fn routes() -> axum::Router<imkitchen_web_shared::AppState> {
             post(routes::users::toggle_premium),
         )
         .route("/admin/users/{id}/edit", get(routes::users::edit_modal))
-        .route("/admin/users/{id}/role", post(routes::users::update_role))
+        .route("/admin/users/{id}", post(routes::users::update_user))
         .route("/admin/invoices", get(routes::invoices::page))
         .route("/admin/invoices/{id}", get(routes::invoices::detail))
         .route("/admin/contact", get(routes::contact::page))

--- a/web/admin/src/routes/users.rs
+++ b/web/admin/src/routes/users.rs
@@ -244,20 +244,26 @@ pub async fn edit_modal(
 }
 
 #[derive(Deserialize)]
-pub struct UpdateRoleForm {
+pub struct UpdateUserForm {
+    pub email: String,
     pub role: String,
 }
 
 #[tracing::instrument(skip_all, fields(admin = admin.id))]
-pub async fn update_role(
+pub async fn update_user(
     template: Template,
     Path((id,)): Path<(String,)>,
     State(app): State<AppState>,
     admin: AuthAdmin,
-    axum::Form(form): axum::Form<UpdateRoleForm>,
+    axum::Form(form): axum::Form<UpdateUserForm>,
 ) -> impl IntoResponse {
     let role = imkitchen_web_shared::try_response!(sync anyhow:
         Role::from_str(&form.role).map_err(|_| anyhow::anyhow!("invalid role")),
+        template
+    );
+
+    imkitchen_web_shared::try_response!(
+        app.identity.change_email(&id, form.email, &admin.id),
         template
     );
 


### PR DESCRIPTION
## Context

Admins could edit a user's **role**, suspend/activate, and toggle premium from `/admin/users` — but **email was immutable after registration** (set once via the `Registered` event, never changed anywhere). Support/admin staff need to correct a user's email for typos, address changes, and account recovery.

## What changed

**Domain (event-sourced identity crate)**
- New `EmailChanged { value }` event on the `User` aggregate.
- New `change_email` command modeled on `set_username`: validates format (`#[validate(email)]`), no-ops when unchanged (case-insensitive), rejects duplicates with the same `"Email already exists"` message used at registration, updates the `user` table, then commits the event with `requested_by(admin)`.
- Extended `repository::UpdateInput` with an `email` field.

**Projections** — `EmailChanged` is handled everywhere the `User` aggregate is projected:
- `AdminView` and `LoginView` update `email` (the latter also updates each nested session `login.email`, keeping `AuthUser.email` correct).
- The lean strict `User` projection skips it.

**Search** — new `m0008` migration recreates the `user_admin_update` FTS trigger to sync `email` (previously only `username` was re-indexed), so a changed email is immediately searchable.

**Web/UI**
- Combined role + email into one handler at `POST /admin/users/{id}` (renamed from `POST /admin/users/{id}/role`). Validation/uniqueness errors render into the modal's `#error-message`.
- Added an editable email input above Role in the Edit User modal.

## Behavior

Immediate change, **no verification / no notification** — matches how role and username changes work today (no verification infra exists). Sessions key off user id (JWT `sub`), so existing sessions stay valid; the user logs in with the new email next time.

## Verification

- `cargo test -p imkitchen-identity` — 4 new `change_email` tests (happy path, no-op, duplicate rejection, invalid format) pass; existing identity/db tests still pass. The `m0008` migration applies cleanly via the test setup.
- `make lint` (clippy `-D warnings`) and `make fmt` — clean.
- `cargo build` — full workspace compiles.

Manual: log in as admin → `/admin/users` → Edit a user → change email → row updates; search by the new email finds them; duplicate/invalid email shows an inline error; user logs in with the new address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)