### PR TITLE
fix(admin): avoid "invalid version" during batch recipe import

### DIFF
--- a/crates/core/src/recipe/root/upload_thumbnail.rs
+++ b/crates/core/src/recipe/root/upload_thumbnail.rs
@@ -2,7 +2,7 @@ use evento::{Executor, ProjectionAggregate};
 use imkitchen_types::recipe::ThumbnailUploaded;
 
 impl<E: Executor + Clone> super::Module<E> {
-    pub async fn upload_thunmnail(
+    pub async fn upload_thumbnail(
         &self,
         id: impl Into<String>,
         data: Vec<u8>,

--- a/web/admin/src/import.rs
+++ b/web/admin/src/import.rs
@@ -294,30 +294,33 @@ pub async fn process_zip<E: Executor + Clone>(
                 Ok(recipe_id) => {
                     progress.recipes_imported += 1;
 
-                    if let Some(image) = entry.image
-                        && let Err(e) = recipe.upload_thunmnail(&recipe_id, image, &chef_id).await
-                    {
-                        progress.errors.push(AdminImportError {
-                            scope: "recipe".into(),
-                            name: recipe_name.clone(),
-                            message: format!(
-                                "Recipe imported, but image failed: {}",
-                                user_message(e)
-                            ),
-                        });
-                    }
-
                     // Imported recipes are published to the community (idempotent: a recipe that
-                    // is already shared is left unchanged).
+                    // is already shared is left unchanged). This runs before the thumbnail upload:
+                    // `upload_thumbnail` triggers an async subscription that appends `ThumbnailResized`
+                    // events, bumping the aggregate version and causing a following synchronous write
+                    // to fail with "invalid version". Keeping the thumbnail upload last avoids that race.
                     if let Err(e) = recipe
                         .share_to_community(&recipe_id, &chef_id, username.clone())
                         .await
                     {
                         progress.errors.push(AdminImportError {
                             scope: "recipe".into(),
-                            name: recipe_name,
+                            name: recipe_name.clone(),
                             message: format!(
                                 "Recipe imported, but sharing failed: {}",
+                                user_message(e)
+                            ),
+                        });
+                    }
+
+                    if let Some(image) = entry.image
+                        && let Err(e) = recipe.upload_thumbnail(&recipe_id, image, &chef_id).await
+                    {
+                        progress.errors.push(AdminImportError {
+                            scope: "recipe".into(),
+                            name: recipe_name,
+                            message: format!(
+                                "Recipe imported, but image failed: {}",
                                 user_message(e)
                             ),
                         });

--- a/web/recipe/src/routes/thumbnail.rs
+++ b/web/recipe/src/routes/thumbnail.rs
@@ -66,7 +66,7 @@ pub async fn upload(
     imkitchen_web_shared::try_response!(
         app.core
             .recipe
-            .upload_thunmnail(&id, data.to_vec(), &user.id),
+            .upload_thumbnail(&id, data.to_vec(), &user.id),
         template
     );
     let encoded = STANDARD.encode(&data);


### PR DESCRIPTION
## Problem

During admin batch recipe import (`web/admin/src/import.rs`), some recipes failed with an evento **"invalid version"** error.

Per imported recipe the writes ran in this order:
1. `import()` → commits `Imported` (no async follow-up)
2. `upload_thumbnail()` → commits `ThumbnailUploaded`, which triggers the background subscription `handle_thumbnail_uploaded` (`crates/core/src/recipe/root/mod.rs`). That subscription asynchronously appends three `ThumbnailResized` events, bumping the aggregate version.
3. `share_to_community()` → loads the recipe and does `.write()?.commit()` with the version it just read. If the background `ThumbnailResized` events had already landed, the version had moved on and the optimistic-concurrency commit failed with **"invalid version"**.

## Fix

Run `share_to_community` **before** `upload_thumbnail`, so the thumbnail upload is the last synchronous write and the racing `ThumbnailResized` background events have nothing after them to conflict with.

Behavior is otherwise unchanged: sharing still always runs; the thumbnail upload still only runs when an image is present.

Also fixes the misspelled `upload_thunmnail` method name → `upload_thumbnail` (definition + both call sites).

## Verification

- [x] `cargo build` for `imkitchen-web-admin`, `imkitchen-web-recipe`, `imkitchen-core`
- [ ] `cargo test -p imkitchen-web-admin` / `cargo test -p imkitchen-core recipe`
- [ ] End-to-end: import a ZIP with an author folder containing a recipe `.json` + matching image; confirm no "invalid version" errors and the recipe is both shared and has thumbnail variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)