### PR TITLE
feat(recipe): add public cook page and link usernames from recipe detail

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:1.96-alpine
+FROM rust:1.97-alpine
 
 RUN apk add --no-cache musl-dev tzdata \
         openssl-dev openssl-libs-static \

--- a/crates/billing/src/scheduler.rs
+++ b/crates/billing/src/scheduler.rs
@@ -103,21 +103,21 @@ async fn renew_subscription<E: Executor + Clone>(
     let Some(customer_id) = subscription.customer_id else {
         anyhow::bail!(
             "failed to renew user subscription, no customer_id found for {}",
-            &subscription.id
+            subscription.id
         );
     };
 
     let Some(payment_method_id) = subscription.payment_method_id else {
         anyhow::bail!(
             "failed to renew user subscription, no payment_method_id found for {}",
-            &subscription.id
+            subscription.id
         );
     };
 
     let Some(payment_details) = subscription.payment_details else {
         anyhow::bail!(
             "failed to renew user subscription, no payment_details found for {}",
-            &subscription.id
+            subscription.id
         );
     };
 

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -269,6 +269,32 @@ impl<E: Executor> crate::recipe::Module<E> {
         )
     }
 
+    /// Resolves a cook's username to their owner id, considering only shared,
+    /// non-draft recipes. `owner_name` mirrors the unique `User.username`, so a
+    /// single row is enough. Returns `None` when the cook has no shared recipes.
+    pub async fn find_owner_id_by_name(
+        &self,
+        name: impl Into<String>,
+    ) -> anyhow::Result<Option<String>> {
+        let statement = sea_query::Query::select()
+            .columns([RecipeUser::OwnerId])
+            .from(RecipeUser::Table)
+            .and_where(Expr::col(RecipeUser::OwnerName).eq(name.into()))
+            .and_where(Expr::col(RecipeUser::IsShared).eq(true))
+            .and_where(Expr::col(RecipeUser::Name).not_equals(""))
+            .limit(1)
+            .to_owned();
+
+        let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+
+        Ok(
+            sqlx::query_as_with::<_, (String,), _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&self.read_db)
+                .await?
+                .map(|(owner_id,)| owner_id),
+        )
+    }
+
     pub async fn find_user_draft(
         &self,
         user_id: impl Into<String>,

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1781147846,
-        "narHash": "sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=",
+        "lastModified": 1783614422,
+        "narHash": "sha256-zSX553aXiIKJHWzUF6nrDKgeNRlfNK/SdyNYSbs2nkM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "107c334f141854f563f8adf1db781dc453d92639",
+        "rev": "e8e9d70b96113fd49ccde6c3e08fb260b6ef5dd6",
         "type": "github"
       },
       "original": {

--- a/templates/recipes-cook.html
+++ b/templates/recipes-cook.html
@@ -1,0 +1,251 @@
+{% extends "_user.html" %}
+{% block title %}@{{ username }} - imkitchen{% endblock %}
+
+{% macro lazy_thumbnail(recipe, version) %}
+{% if let Some(blur) = recipe.blur_placeholder %}
+<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
+{% endif %}
+<picture>
+  <source data-media="(max-width: 480px)"
+    data-srcset="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" />
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+    data-src="/recipes/{{ recipe.id }}/thumbnail/tablet/image.webp?v={{ version }}" alt="{{ recipe.name }}"
+    class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 [&.loaded]:opacity-100"
+    ts-trigger="closeby once" ts-action="lazy" />
+</picture>
+{% endmacro %}
+
+{# Map RecipeType → emoji + meal-color classes (mirrors recipes-index.html) #}
+{% macro type_emoji(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}🥗
+{%- when RecipeType::MainCourse -%}🍛
+{%- when RecipeType::Accompaniment -%}🥖
+{%- when RecipeType::Dessert -%}🍰
+{%- when RecipeType::Beverage -%}🥤
+{%- when RecipeType::Condiment -%}🥫
+{%- endmatch -%}
+{%- endmacro %}
+
+{% macro type_hero_classes(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}from-meal-entree-soft to-blue-100
+{%- when RecipeType::MainCourse -%}from-meal-main-soft to-orange-100
+{%- when RecipeType::Accompaniment -%}from-meal-side-soft to-herb-100
+{%- when RecipeType::Dessert -%}from-meal-dessert-soft to-pink-100
+{%- when RecipeType::Beverage -%}from-cyan-100 to-cyan-200
+{%- when RecipeType::Condiment -%}from-amber-100 to-amber-200
+{%- endmatch -%}
+{%- endmacro %}
+
+{% macro type_pill_classes(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}bg-meal-entree-soft text-meal-entree-ink
+{%- when RecipeType::MainCourse -%}bg-meal-main-soft text-meal-main-ink
+{%- when RecipeType::Accompaniment -%}bg-meal-side-soft text-meal-side-ink
+{%- when RecipeType::Dessert -%}bg-meal-dessert-soft text-meal-dessert-ink
+{%- when RecipeType::Beverage -%}bg-cyan-100 text-cyan-900
+{%- when RecipeType::Condiment -%}bg-amber-100 text-amber-900
+{%- endmatch -%}
+{%- endmacro %}
+
+{% macro type_ink_class(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}text-meal-entree-ink
+{%- when RecipeType::MainCourse -%}text-meal-main-ink
+{%- when RecipeType::Accompaniment -%}text-meal-side-ink
+{%- when RecipeType::Dessert -%}text-meal-dessert-ink
+{%- when RecipeType::Beverage -%}text-cyan-900
+{%- when RecipeType::Condiment -%}text-amber-900
+{%- endmatch -%}
+{%- endmacro %}
+
+{% block content %}
+{% let active_type = query.recipe_type.as_deref().unwrap_or("") %}
+{% let view = query.view.as_deref().unwrap_or("grid") %}
+{% let cook_url = "/cooks/"|demo_href %}
+
+<div class="container mx-auto px-4 py-6 md:py-8">
+
+  {# ── Cook header ──────────────────────────────────────────── #}
+  <header class="mb-5 md:mb-7 bg-paper border border-line-2 rounded-2xl p-4 md:p-5 flex items-start gap-3">
+    <div class="w-11 h-11 shrink-0 {{ username|bg_color }} rounded-full flex items-center justify-center text-white font-bold text-sm">
+      {{ username|initials }}
+    </div>
+    <div class="flex-1 min-w-0">
+      <div class="font-semibold text-ink">@{{ username }}</div>
+      <div class="text-xs text-ink-3 mt-0.5">{{ stat.shared }} {{ "recipes shared"|t }}</div>
+      {% if !owner_description.is_empty() %}
+      <p class="text-sm text-ink-2 mt-2 leading-relaxed">{{ owner_description|nl2br|safe }}</p>
+      {% endif %}
+    </div>
+  </header>
+
+  {# ── Filters form — scoped to this cook ─────────────────────── #}
+  <form ts-trigger="change,input" ts-req="{{ cook_url }}{{ username }}" ts-req-selector="#recipes-list" ts-req-method="GET"
+    ts-req-strategy="last" ts-target="#recipes-list" autocomplete="off">
+
+    {# Header row — count on the left, view toggle on the right #}
+    <div class="flex items-center justify-between gap-3 mb-4">
+      <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3">
+        {{ "Library"|t }} · {{ recipes.edges.len() }} {{ "recipes"|t }}
+      </div>
+
+      {# View toggle (grid | list) #}
+      <div class="inline-flex p-1 bg-cream-2 rounded-xl gap-0.5 shrink-0">
+        <input type="radio" name="view" value="grid" id="view-grid" class="peer/g sr-only"
+          {% if view == "grid" %}checked{% endif %}/>
+        <label for="view-grid" title="{{ "Grid"|t }}"
+          class="w-8 h-8 flex items-center justify-center rounded-lg cursor-pointer text-ink-2 transition
+            peer-checked/g:bg-paper peer-checked/g:shadow-sm peer-checked/g:text-ink">
+          <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M2 2h5v5H2zM9 2h5v5H9zM2 9h5v5H2zM9 9h5v5H9z"/>
+          </svg>
+        </label>
+        <input type="radio" name="view" value="list" id="view-list" class="peer/l sr-only"
+          {% if view == "list" %}checked{% endif %}/>
+        <label for="view-list" title="{{ "List"|t }}"
+          class="w-8 h-8 flex items-center justify-center rounded-lg cursor-pointer text-ink-2 transition
+            peer-checked/l:bg-paper peer-checked/l:shadow-sm peer-checked/l:text-ink">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 16 16">
+            <path stroke-linecap="round" d="M2 4h12M2 8h12M2 12h12"/>
+          </svg>
+        </label>
+      </div>
+    </div>
+
+    {# Search #}
+    <div class="flex gap-2 mb-3">
+      <label class="flex-1 flex items-center gap-2 h-11 px-3.5 bg-paper border border-line-2 rounded-2xl
+        focus-within:border-primary-400 focus-within:ring-2 focus-within:ring-primary-100 transition">
+        <svg class="w-4 h-4 text-ink-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <circle cx="11" cy="11" r="7"></circle>
+          <path stroke-linecap="round" d="m20 20-3-3"></path>
+        </svg>
+        <input name="search" type="text" value="{{ query.search.as_deref().unwrap_or("") }}"
+          placeholder="{{ "Search by name, description or ingredient..."|t }}"
+          class="flex-1 min-w-0 bg-transparent outline-none text-sm placeholder:text-ink-3"/>
+      </label>
+    </div>
+
+    {# Type chips + Sort #}
+    <div class="flex flex-wrap items-center gap-1.5 mb-5 md:mb-6">
+      {# "All" chip — empty recipe_type #}
+      <label class="inline-flex items-center gap-1.5 px-3 py-2 rounded-full border text-xs font-semibold
+        cursor-pointer transition bg-paper border-line-2 text-ink hover:bg-cream
+        has-checked:bg-ink has-checked:text-cream has-checked:border-ink">
+        <input type="radio" name="recipe_type" value="" class="sr-only"
+          {% if active_type == "" %}checked{% endif %}/>
+        <span>🍴</span> {{ "All"|t }}
+      </label>
+
+      {% for variant in RecipeType::VARIANTS %}
+      <label class="inline-flex items-center gap-1.5 px-3 py-2 rounded-full border text-xs font-semibold
+        cursor-pointer transition bg-paper border-line-2 text-ink hover:bg-cream
+        has-checked:bg-ink has-checked:text-cream has-checked:border-ink">
+        <input type="radio" name="recipe_type" value="{{ variant }}" class="sr-only"
+          {% if active_type == variant.to_string() %}checked{% endif %}/>
+        <span>{% call type_emoji(variant) %}{% endcall %}</span>
+        {{ variant.as_ref()|t }}
+      </label>
+      {% endfor %}
+
+      {# Sort — subtle inline select #}
+      <label class="inline-flex items-center gap-1.5 px-3 py-2 rounded-full border border-line-2 bg-paper text-xs
+        font-mono uppercase tracking-wider text-ink-3 cursor-pointer lg:ml-auto">
+        <span>{{ "Sort"|t }}</span>
+        <select name="sort_by" class="bg-transparent outline-none font-semibold text-ink uppercase tracking-wider">
+          <option value="{{ SortBy::RecentlyAdded }}"
+            {% if let Some(SortBy::RecentlyAdded) = query.sort_by %}selected{% endif %}>{{ "Recently Added"|t }}</option>
+          <option value="{{ SortBy::Easiest }}"
+            {% if let Some(SortBy::Easiest) = query.sort_by %}selected{% endif %}>{{ "Easiest"|t }}</option>
+          <option value="{{ SortBy::Hardest }}"
+            {% if let Some(SortBy::Hardest) = query.sort_by %}selected{% endif %}>{{ "Hardest"|t }}</option>
+        </select>
+      </label>
+    </div>
+  </form>
+
+  {# ── Results ────────────────────────────────────────────────── #}
+  <div id="recipes-list" class="{% if view == "list" %}grid gap-2{% else %}grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3 md:gap-4{% endif %}">
+    {% if recipes.edges.is_empty() %}
+    <div class="col-span-full">
+      <div class="bg-paper border border-line-2 rounded-2xl p-10 md:p-14 flex flex-col items-center text-center
+        shadow-sm">
+        <span class="text-5xl mb-4">🍽️</span>
+        <div class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-1">
+          {{ "Empty"|t }}
+        </div>
+        <h3 class="font-serif text-2xl text-ink mb-2">{{ "No recipes found"|t }}</h3>
+        <p class="text-sm text-ink-3 max-w-sm">{{ "Try adjusting your filters"|t }}</p>
+      </div>
+    </div>
+
+    {% else %}
+    {% for recipe in recipes.edges %}
+    {% let rt = recipe.node.recipe_type.0 %}
+
+    {% if view == "list" %}
+    {# ── List row ── #}
+    <a id="recipe-{{ recipe.node.id }}" href="{{ "/r/"|demo_href }}{{ recipe.node.slug }}"
+      {% if let (true, true, Some(cursor)) = (loop.last, recipes.page_info.has_next_page, recipes.page_info.end_cursor.to_owned()) %}
+      ts-req="{{ cook_url }}{{ username }}?after={{ cursor.to_string() }}{% if let Some(sort_by) = query.sort_by %}&sort_by={{ sort_by }}{% endif %}{% if let Some(recipe_type) = query.recipe_type %}&recipe_type={{ recipe_type }}{% endif %}{% if let Some(search) = query.search %}&search={{ search }}{% endif %}&view=list"
+      ts-req-method="GET" ts-req-selector="children #recipes-list" ts-swap="afterend" ts-trigger="visible once"
+      {% endif %}
+      class="min-w-0 bg-paper border border-line-2 rounded-2xl px-3 py-2.5 shadow-sm hover:shadow-md transition flex items-center gap-3">
+      <div class="relative w-12 h-12 rounded-xl overflow-hidden bg-linear-to-br {% call type_hero_classes(rt) %}{% endcall %}
+        flex items-center justify-center shrink-0">
+        {% if let Some(version) = recipe.node.thumbnail_version %}
+          {% call lazy_thumbnail(recipe.node, version) %}{% endcall %}
+        {% else %}
+          <span class="text-2xl">{% call type_emoji(rt) %}{% endcall %}</span>
+        {% endif %}
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="text-[10px] font-semibold tracking-wider uppercase font-mono {% call type_ink_class(rt) %}{% endcall %}">
+          {{ rt.as_ref()|t }}
+        </div>
+        <div class="text-sm font-semibold text-ink truncate mt-0.5">{{ recipe.node.name }}</div>
+        <div class="text-xs text-ink-3 mt-0.5 flex items-center gap-2 flex-wrap">
+          <span>⏱ {{ (recipe.node.cook_time + recipe.node.prep_time)|minutes }}</span>
+        </div>
+      </div>
+      <svg class="w-4 h-4 text-ink-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m9 6 6 6-6 6"/>
+      </svg>
+    </a>
+
+    {% else %}
+    {# ── Grid card ── #}
+    <a id="recipe-{{ recipe.node.id }}" href="{{ "/r/"|demo_href }}{{ recipe.node.slug }}"
+      {% if let (true, true, Some(cursor)) = (loop.last, recipes.page_info.has_next_page, recipes.page_info.end_cursor.to_owned()) %}
+      ts-req="{{ cook_url }}{{ username }}?after={{ cursor.to_string() }}{% if let Some(sort_by) = query.sort_by %}&sort_by={{ sort_by }}{% endif %}{% if let Some(recipe_type) = query.recipe_type %}&recipe_type={{ recipe_type }}{% endif %}{% if let Some(search) = query.search %}&search={{ search }}{% endif %}"
+      ts-req-method="GET" ts-req-selector="children #recipes-list" ts-swap="afterend" ts-trigger="visible once"
+      {% endif %}
+      class="group bg-paper border border-line-2 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden flex flex-col">
+      <div class="relative h-28 md:h-36 bg-linear-to-br {% call type_hero_classes(rt) %}{% endcall %} flex items-center justify-center overflow-hidden">
+        {% if let Some(version) = recipe.node.thumbnail_version %}
+          {% call lazy_thumbnail(recipe.node, version) %}{% endcall %}
+        {% else %}
+          <span class="text-5xl md:text-6xl drop-shadow-sm">{% call type_emoji(rt) %}{% endcall %}</span>
+        {% endif %}
+        <span class="absolute top-2 left-2 px-2 py-0.5 rounded-full text-[10px] font-semibold
+          bg-paper/90 backdrop-blur-sm {% call type_pill_classes(rt) %}{% endcall %}">
+          {{ rt.as_ref()|t }}
+        </span>
+        <span class="absolute top-2 right-2 px-2 py-0.5 rounded-full text-[10px] font-semibold
+          bg-paper/90 backdrop-blur-sm text-ink-2 inline-flex items-center gap-1">
+          ⏱ {{ (recipe.node.cook_time + recipe.node.prep_time)|minutes }}
+        </span>
+      </div>
+      <div class="p-3 md:p-3.5 flex-1 flex flex-col gap-1.5">
+        <h3 class="font-semibold text-ink text-sm md:text-[15px] leading-tight line-clamp-2">{{ recipe.node.name }}</h3>
+      </div>
+    </a>
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+  </div>
+
+</div>
+{% endblock %}

--- a/templates/recipes-detail.html
+++ b/templates/recipes-detail.html
@@ -305,7 +305,7 @@
           {{ owner_name|initials }}
         </div>
         <div class="flex-1 min-w-0">
-          <div class="font-semibold text-ink">@{{ owner_name }}</div>
+          <a href="{{ "/cooks/"|demo_href }}{{ owner_name }}" class="font-semibold text-ink hover:text-primary-500 transition">@{{ owner_name }}</a>
           <div class="text-xs text-ink-3 mt-0.5">{{ stat.shared }} {{ "recipes shared"|t }}</div>
           {% if !owner_description.is_empty() %}
           <p class="text-sm text-ink-2 mt-2 leading-relaxed">{{ owner_description|nl2br|safe }}</p>
@@ -409,19 +409,6 @@
     {# ───────────────────── RIGHT rail ───────────────────── #}
     <aside class="xl:w-90 shrink-0 min-w-0">
       <div class="xl:sticky xl:top-4 space-y-5">
-        {% if !cook_recipes.edges.is_empty() %}
-        <section>
-          <h3 class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-3">
-            {{ "More from this cook"|t }}
-          </h3>
-          <div class="space-y-3">
-            {% for cook_recipe in cook_recipes.edges.iter() %}
-              {% call suggestion_card(cook_recipe.node) %}{% endcall %}
-            {% endfor %}
-          </div>
-        </section>
-        {% endif %}
-
         {% if !similar_recipes.edges.is_empty() %}
         <section>
           <h3 class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-3">

--- a/web/demo/src/fixtures.rs
+++ b/web/demo/src/fixtures.rs
@@ -21,6 +21,7 @@ use imkitchen_types::recipe::{
 use imkitchen_web_grocery::{AisleSection, GroceriesTemplate};
 use imkitchen_web_kitchen::{CookingTemplate, KitchenTemplate, KitchenWeekDay};
 use imkitchen_web_menu::{MenuBoardDay, MenuSlot, MenuTemplate};
+use imkitchen_web_recipe::routes::cook::{CookTemplate, PageQuery as CookPageQuery};
 use imkitchen_web_recipe::routes::detail::DetailTemplate;
 use imkitchen_web_recipe::routes::index::{IndexTemplate as RecipesIndexTemplate, PageQuery};
 use imkitchen_web_shared::auth::AuthUser;
@@ -898,13 +899,6 @@ pub fn recipe_detail(id: &str) -> DetailTemplate<'static> {
     let rt = recipe.recipe_type.0.clone();
     let current_id = recipe.id.clone();
 
-    let cook_nodes: Vec<UserViewList> = catalog()
-        .iter()
-        .filter(|r| r.id != current_id)
-        .take(2)
-        .map(to_list)
-        .collect();
-
     let similar_nodes: Vec<UserViewList> = catalog()
         .iter()
         .filter(|r| r.id != current_id && r.recipe_type.0 == rt)
@@ -921,9 +915,51 @@ pub fn recipe_detail(id: &str) -> DetailTemplate<'static> {
             ..Default::default()
         },
         favorite: Favorite::default(),
-        cook_recipes: to_read_result(cook_nodes),
         similar_recipes: to_read_result(similar_nodes),
         owner_description: "Home cook sharing tried-and-tested family recipes.".to_owned(),
+        ..Default::default()
+    }
+}
+
+// ── Cook's recipes page ──────────────────────────────────────────────────
+
+pub fn cook(username: &str, query: CookPageQuery) -> CookTemplate {
+    let search = query.search.clone().unwrap_or_default().to_lowercase();
+    let recipe_type = query
+        .recipe_type
+        .as_deref()
+        .and_then(|v| RecipeType::from_str(v).ok());
+
+    // The whole demo catalog stands in for this cook's shared recipes. Type
+    // chips, search and sort behave like the real page.
+    let mut matches: Vec<UserView> = catalog()
+        .into_iter()
+        .filter(|r| recipe_type.as_ref().is_none_or(|rt| &r.recipe_type.0 == rt))
+        .filter(|r| {
+            search.is_empty()
+                || r.name.to_lowercase().contains(&search)
+                || r.description.to_lowercase().contains(&search)
+        })
+        .collect();
+
+    match &query.sort_by {
+        Some(SortBy::Easiest) => matches.sort_by_key(|r| r.difficulty_score),
+        Some(SortBy::Hardest) => matches.sort_by_key(|r| std::cmp::Reverse(r.difficulty_score)),
+        _ => {}
+    }
+
+    let recipes = to_read_result(matches.iter().map(to_list).collect());
+
+    CookTemplate {
+        user: demo_user(),
+        username: username.to_owned(),
+        stat: UserStatView {
+            shared: catalog().len() as u32,
+            ..Default::default()
+        },
+        owner_description: "Home cook sharing tried-and-tested family recipes.".to_owned(),
+        recipes,
+        query,
         ..Default::default()
     }
 }

--- a/web/demo/src/lib.rs
+++ b/web/demo/src/lib.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use axum_extra::extract::Query;
 
+use imkitchen_web_recipe::routes::cook::PageQuery as CookPageQuery;
 use imkitchen_web_recipe::routes::index::PageQuery;
 use imkitchen_web_shared::{
     AppState,
@@ -36,6 +37,7 @@ pub fn routes() -> axum::Router<AppState> {
         .route("/demo/recipes", get(recipes))
         .route("/demo/recipes/{id}", get(recipes_detail))
         .route("/demo/r/{slug}", get(recipes_detail))
+        .route("/demo/cooks/{username}", get(cooks))
         .route("/demo/groceries", get(groceries))
         .route("/demo/signup", get(signup_modal))
 }
@@ -76,6 +78,14 @@ async fn recipes_detail(template: Template, Path((slug,)): Path<(String,)>) -> i
     } else {
         Redirect::to(&format!("/r/{slug}")).into_response()
     }
+}
+
+async fn cooks(
+    template: Template,
+    Path((username,)): Path<(String,)>,
+    Query(query): Query<CookPageQuery>,
+) -> impl IntoResponse {
+    template.demo().render(fixtures::cook(&username, query))
 }
 
 async fn groceries(template: Template) -> impl IntoResponse {

--- a/web/recipe/src/lib.rs
+++ b/web/recipe/src/lib.rs
@@ -44,6 +44,7 @@ pub fn routes() -> axum::Router<imkitchen_web_shared::AppState> {
             get(routes::thumbnail::get),
         )
         .route("/recipes/{id}/thumbnail", post(routes::thumbnail::upload))
+        .route("/cooks/{username}", get(routes::cook::page))
         .route("/r/{slug}", get(routes::detail::page))
         .route("/recipes/{id}", get(routes::detail::redirect_to_slug))
         .route(

--- a/web/recipe/src/routes/cook.rs
+++ b/web/recipe/src/routes/cook.rs
@@ -1,0 +1,137 @@
+use axum::{extract::State, response::IntoResponse};
+use axum_extra::extract::Query;
+use evento::cursor::{Args, ReadResult, Value};
+use imkitchen_core::recipe::query::{
+    user::{RecipesQuery, SortBy, UserViewList},
+    user_stat::UserStatView,
+};
+use imkitchen_types::recipe::RecipeType;
+use serde::Deserialize;
+use std::str::FromStr;
+use strum::VariantArray;
+
+use imkitchen_web_shared::{
+    AppState,
+    auth::AuthUser,
+    template::{NotFoundTemplate, Template, filters},
+};
+
+#[derive(askama::Template)]
+#[template(path = "recipes-cook.html")]
+pub struct CookTemplate {
+    pub current_path: String,
+    pub user: AuthUser,
+    /// The cook's username — used for the header and to build filter / load-more URLs.
+    pub username: String,
+    pub stat: UserStatView,
+    pub owner_description: String,
+    pub recipes: ReadResult<UserViewList>,
+    pub query: PageQuery,
+}
+
+impl Default for CookTemplate {
+    fn default() -> Self {
+        Self {
+            current_path: "recipes".to_owned(),
+            user: AuthUser::default(),
+            username: String::new(),
+            stat: UserStatView::default(),
+            owner_description: String::new(),
+            recipes: ReadResult::default(),
+            query: Default::default(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+pub struct PageQuery {
+    pub first: Option<u16>,
+    pub after: Option<Value>,
+    pub last: Option<u16>,
+    pub before: Option<Value>,
+    pub recipe_type: Option<String>,
+    pub search: Option<String>,
+    pub sort_by: Option<SortBy>,
+    pub view: Option<String>,
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn page(
+    template: Template,
+    user: Option<AuthUser>,
+    axum::extract::Path((username,)): axum::extract::Path<(String,)>,
+    State(app): State<AppState>,
+    Query(input): Query<PageQuery>,
+) -> impl IntoResponse {
+    let owner_id = match imkitchen_web_shared::try_page_response!(
+        app.core.recipe.find_owner_id_by_name(&username),
+        template
+    ) {
+        Some(id) => id,
+        None => return template.render(NotFoundTemplate).into_response(),
+    };
+
+    // Public page: anonymous visitors get a demo "guest" identity and the page
+    // renders in demo mode — links stay under /demo and actions funnel to
+    // sign-up (mirrors the public recipe detail page).
+    let is_anonymous = user.is_none();
+    let user = user.unwrap_or_else(AuthUser::demo);
+    let template = if is_anonymous {
+        template.demo()
+    } else {
+        template
+    };
+
+    let stat = imkitchen_web_shared::try_page_response!(
+        app.core.recipe.find_user_stat(&owner_id),
+        template
+    )
+    .unwrap_or_default();
+
+    let owner_profile = imkitchen_web_shared::try_page_response!(
+        app.identity.user_profile.load(&owner_id),
+        template
+    );
+
+    let query = input.clone();
+
+    let args = Args {
+        first: input.first,
+        after: input.after,
+        last: input.last,
+        before: input.before,
+    };
+
+    let recipe_type = input
+        .recipe_type
+        .and_then(|v| RecipeType::from_str(v.as_str()).ok());
+
+    let recipes = imkitchen_web_shared::try_page_response!(
+        app.core.recipe.filter_user(RecipesQuery {
+            exclude_ids: None,
+            user_id: Some(owner_id),
+            recipe_type,
+            is_shared: Some(true),
+            has_thumbnail: None,
+            dietary_restrictions: vec![],
+            dietary_where_any: false,
+            in_meal_plan: None,
+            sort_by: input.sort_by.unwrap_or_default(),
+            args: args.limit(20),
+            search: input.search,
+        }),
+        template
+    );
+
+    template
+        .render(CookTemplate {
+            user,
+            username,
+            stat,
+            owner_description: owner_profile.description,
+            recipes,
+            query,
+            ..Default::default()
+        })
+        .into_response()
+}

--- a/web/recipe/src/routes/detail.rs
+++ b/web/recipe/src/routes/detail.rs
@@ -52,7 +52,6 @@ pub struct DetailTemplate<'a> {
     pub recipe: UserView,
     pub stat: UserStatView,
     pub favorite: favorite::Favorite,
-    pub cook_recipes: ReadResult<UserViewList>,
     pub similar_recipes: ReadResult<UserViewList>,
     pub owner_description: String,
     /// Pre-serialized schema.org/Recipe JSON-LD for search-engine rich
@@ -154,7 +153,6 @@ impl<'a> Default for DetailTemplate<'a> {
             user: AuthUser::default(),
             recipe: Default::default(),
             stat: UserStatView::default(),
-            cook_recipes: Default::default(),
             similar_recipes: Default::default(),
             favorite: Default::default(),
             username: "john_doe",
@@ -224,31 +222,6 @@ pub async fn page(
     .to_owned();
 
     let exclude_ids = vec![recipe.id.to_owned()];
-
-    let cook_recipes = imkitchen_web_shared::try_page_response!(
-        app.core.recipe.filter_user(RecipesQuery {
-            exclude_ids: Some(exclude_ids),
-            user_id: Some(recipe.owner_id.to_owned()),
-            recipe_type: None,
-            is_shared: Some(true),
-            has_thumbnail: None,
-            dietary_restrictions: vec![],
-            dietary_where_any: false,
-            in_meal_plan: None,
-            sort_by: SortBy::RecentlyAdded,
-            args: Args::forward(2, None),
-            search: None,
-        }),
-        template
-    );
-
-    let mut exclude_ids = cook_recipes
-        .edges
-        .iter()
-        .map(|n| n.node.id.to_owned())
-        .collect::<Vec<_>>();
-
-    exclude_ids.push(recipe.id.to_owned());
 
     let mut similar_recipes = imkitchen_web_shared::try_page_response!(
         app.core.recipe.filter_user(RecipesQuery {
@@ -338,7 +311,6 @@ pub async fn page(
             user,
             recipe,
             stat,
-            cook_recipes,
             similar_recipes,
             favorite,
             username: username.as_str(),

--- a/web/recipe/src/routes/mod.rs
+++ b/web/recipe/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod cook;
 pub mod detail;
 pub mod edit;
 pub mod import;

--- a/web/shared/src/auth.rs
+++ b/web/shared/src/auth.rs
@@ -101,8 +101,8 @@ impl FromRequestParts<crate::AppState> for AuthToken {
             .ok_or(Redirect::to("/login"))?;
 
         let mut validation = Validation::new(Algorithm::HS256);
-        validation.set_issuer(&[state.config.jwt.issuer.to_owned()]);
-        validation.set_audience(&[state.config.jwt.audience.to_owned()]);
+        validation.set_issuer(std::slice::from_ref(&state.config.jwt.issuer));
+        validation.set_audience(std::slice::from_ref(&state.config.jwt.audience));
 
         let token_data = decode::<Claims>(
             &token,


### PR DESCRIPTION
## Context

On the recipe detail page (`/r/{slug}`) the author card showed `@username` as plain text. Users wanted to click a username and see **only** that cook's recipes. With a dedicated cook page now doing that, the small "More from this cook" right-rail section became redundant.

## What changed

**New public page `/cooks/{username}`** — lists a cook's shared recipes with recipe-type chips, search, sort, and grid/list toggle (scoped to the cook). Public like `/r/{slug}`: anonymous visitors render in demo mode (nav + links stay under `/demo`, actions funnel to sign-up).
- `web/recipe/src/routes/cook.rs` (new handler + `PageQuery` / `CookTemplate`)
- `templates/recipes-cook.html` (new) — cook header (avatar, `@username`, shared count, bio) + grid/list markup reused from the community browse
- Registered the module + route in `web/recipe/src/routes/mod.rs` / `lib.rs`
- `crates/core/src/recipe/query/user.rs` — new `find_owner_id_by_name()` (resolves username → owner_id among shared, non-draft recipes); reuses existing `filter_user()`, `find_user_stat()`, `user_profile.load()`

**Recipe detail page**
- Author-card `@owner_name` is now a link to the cook page (demo-aware via `demo_href`)
- Removed the "More from this cook" section (Similar recipes retained); dropped the `cook_recipes` field/query and simplified the similar-recipes exclusion

**Demo parity**
- `/demo/cooks/{username}` route backed by a new `cook()` fixture so the tour link never 404s

No new translation keys needed — the page reuses strings already in `locales/fr.json` (English keys are the source strings).

## Verification

Ran the server against the real DB:
- `/cooks/tatiemaryse` → 200, header + 20 recipes; `?search=crabe` narrows 20→7; `?recipe_type=Beverage` returns only beverages
- Anonymous → demo mode (nav/links under `/demo`)
- `/cooks/nonexistent` → Not Found (same soft-404 convention as `/r/bad-slug`)
- Detail page: username links to the cook page, "More from this cook" gone, "Similar recipes" kept
- `/demo/cooks/anna` → 200 from fixtures
- `cargo build` + `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)