### PR TITLE
feat(recipe): lazy-load similar recipes and show 10 randomized

### DIFF
--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -1,7 +1,7 @@
 use base64::{Engine, engine::general_purpose::STANDARD};
 use evento::{
     Cursor, Executor, Projection, Snapshot,
-    cursor::{Args, ReadResult},
+    cursor::{Args, Edge, PageInfo, ReadResult, Value},
     metadata::Event,
     sql::Reader,
 };
@@ -14,7 +14,7 @@ use imkitchen_types::recipe::{
     InstructionsChanged, MadePrivate, MainCourseOptionsChanged, Recipe, RecipeType,
     RecipeTypeChanged, SharedToCommunity, ThumbnailResized,
 };
-use sea_query::{Expr, ExprTrait, OnConflict, Query, SqliteQueryBuilder};
+use sea_query::{Expr, ExprTrait, Func, OnConflict, Query, SimpleExpr, SqliteQueryBuilder};
 use sea_query_sqlx::SqlxBinder;
 use serde::Deserialize;
 use sqlx::{SqlitePool, prelude::FromRow};
@@ -27,6 +27,7 @@ pub enum SortBy {
     RecentlyAdded,
     Easiest,
     Hardest,
+    Random,
 }
 
 #[evento::projection(FromRow)]
@@ -241,6 +242,36 @@ impl<E: Executor> crate::recipe::Module<E> {
                     .await?;
 
                 Ok(result.map(|item| item.0))
+            }
+            // Random ordering is incompatible with cursor pagination, so bypass
+            // `Reader` and run a one-shot `ORDER BY RANDOM()` query (same pattern
+            // as meal-plan generation). The limit comes from the caller's `Args`.
+            SortBy::Random => {
+                let limit = query.args.first.or(query.args.last).unwrap_or(10) as u64;
+
+                statement
+                    .order_by_expr(
+                        SimpleExpr::FunctionCall(Func::random()),
+                        sea_query::Order::Asc,
+                    )
+                    .limit(limit);
+
+                let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+                let nodes =
+                    sqlx::query_as_with::<_, UserViewList, _>(sqlx::AssertSqlSafe(sql), values)
+                        .fetch_all(&self.read_db)
+                        .await?;
+
+                Ok(ReadResult {
+                    edges: nodes
+                        .into_iter()
+                        .map(|node| Edge {
+                            cursor: Value(node.id.clone()),
+                            node,
+                        })
+                        .collect(),
+                    page_info: PageInfo::default(),
+                })
             }
         }
     }

--- a/templates/partials/recipes-similar.html
+++ b/templates/partials/recipes-similar.html
@@ -1,0 +1,73 @@
+{# ── Lazily-loaded "Similar recipes" right-rail fragment (twinspark). ──
+     Rendered on its own via GET /r/{slug}/similar so the detail page can
+     return its main content without waiting on the similar-recipes queries.
+     Macros mirror the ones in recipes-detail.html (redefined per-template,
+     as elsewhere in the codebase). ──────────────────────────────────────── #}
+{% macro type_emoji(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}🥗
+{%- when RecipeType::MainCourse -%}🍛
+{%- when RecipeType::Accompaniment -%}🥖
+{%- when RecipeType::Dessert -%}🍰
+{%- when RecipeType::Beverage -%}🥤
+{%- when RecipeType::Condiment -%}🥫
+{%- endmatch -%}
+{%- endmacro %}
+
+{% macro type_hero_classes(rt) -%}
+{%- match rt -%}
+{%- when RecipeType::Appetizer -%}from-meal-entree-soft to-blue-100
+{%- when RecipeType::MainCourse -%}from-meal-main-soft to-orange-100
+{%- when RecipeType::Accompaniment -%}from-meal-side-soft to-herb-100
+{%- when RecipeType::Dessert -%}from-meal-dessert-soft to-pink-100
+{%- when RecipeType::Beverage -%}from-cyan-100 to-cyan-200
+{%- when RecipeType::Condiment -%}from-amber-100 to-amber-200
+{%- endmatch -%}
+{%- endmacro %}
+
+{% macro lazy_card_thumbnail(recipe, version) %}
+{% if let Some(blur) = recipe.blur_placeholder %}
+<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
+{% endif %}
+<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+  data-src="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" alt="{{ recipe.name }}"
+  class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 [&.loaded]:opacity-100"
+  ts-trigger="closeby once" ts-action="lazy" />
+{% endmacro %}
+
+{# ── Compact suggestion card used in the right rail ── #}
+{% macro suggestion_card(node) %}
+{% let srt = node.recipe_type.0 %}
+<a href="{{ "/r/"|demo_href }}{{ node.slug }}" class="flex gap-3 group">
+  <div class="relative w-32 h-20 rounded-xl overflow-hidden bg-linear-to-br {% call type_hero_classes(srt) %}{% endcall %}
+    flex items-center justify-center shrink-0">
+    {% if let Some(version) = node.thumbnail_version %}
+      {% call lazy_card_thumbnail(node, version) %}{% endcall %}
+    {% else %}
+      <span class="text-3xl">{% call type_emoji(srt) %}{% endcall %}</span>
+    {% endif %}
+  </div>
+  <div class="flex-1 min-w-0">
+    <h4 class="font-semibold text-sm text-ink leading-snug line-clamp-2 group-hover:text-primary-500">
+      {{ node.name }}
+    </h4>
+    {% if let Some(username) = node.owner_name %}
+    <p class="text-[11px] text-ink-3 mt-1">@{{ username }}</p>
+    {% endif %}
+    <p class="text-[11px] text-ink-3 mt-0.5">{{ node.created_at|relative_time }}</p>
+  </div>
+</a>
+{% endmacro %}
+
+{% if !similar_recipes.edges.is_empty() %}
+<section>
+  <h3 class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-3">
+    {{ "Similar recipes"|t }}
+  </h3>
+  <div class="space-y-3">
+    {% for similar_recipe in similar_recipes.edges.iter() %}
+      {% call suggestion_card(similar_recipe.node) %}{% endcall %}
+    {% endfor %}
+  </div>
+</section>
+{% endif %}

--- a/templates/recipes-detail.html
+++ b/templates/recipes-detail.html
@@ -64,40 +64,6 @@
 </picture>
 {% endmacro %}
 
-{% macro lazy_card_thumbnail(recipe, version) %}
-{% if let Some(blur) = recipe.blur_placeholder %}
-<div class="absolute inset-0 bg-cover bg-center scale-110 blur-lg" style="background-image:url({{ blur }})"></div>
-{% endif %}
-<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-  data-src="/recipes/{{ recipe.id }}/thumbnail/mobile/image.webp?v={{ version }}" alt="{{ recipe.name }}"
-  class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 [&.loaded]:opacity-100"
-  ts-trigger="closeby once" ts-action="lazy" />
-{% endmacro %}
-
-{# ── Compact suggestion card used in the right rail ── #}
-{% macro suggestion_card(node) %}
-{% let srt = node.recipe_type.0 %}
-<a href="{{ "/r/"|demo_href }}{{ node.slug }}" class="flex gap-3 group">
-  <div class="relative w-32 h-20 rounded-xl overflow-hidden bg-linear-to-br {% call type_hero_classes(srt) %}{% endcall %}
-    flex items-center justify-center shrink-0">
-    {% if let Some(version) = node.thumbnail_version %}
-      {% call lazy_card_thumbnail(node, version) %}{% endcall %}
-    {% else %}
-      <span class="text-3xl">{% call type_emoji(srt) %}{% endcall %}</span>
-    {% endif %}
-  </div>
-  <div class="flex-1 min-w-0">
-    <h4 class="font-semibold text-sm text-ink leading-snug line-clamp-2 group-hover:text-primary-500">
-      {{ node.name }}
-    </h4>
-    {% if let Some(username) = node.owner_name %}
-    <p class="text-[11px] text-ink-3 mt-1">@{{ username }}</p>
-    {% endif %}
-    <p class="text-[11px] text-ink-3 mt-0.5">{{ node.created_at|relative_time }}</p>
-  </div>
-</a>
-{% endmacro %}
-
 {% block content %}
 {% let demo = ""|is_demo %}
 {% let rt = recipe.recipe_type.0 %}
@@ -409,18 +375,23 @@
     {# ───────────────────── RIGHT rail ───────────────────── #}
     <aside class="xl:w-90 shrink-0 min-w-0">
       <div class="xl:sticky xl:top-4 space-y-5">
-        {% if !similar_recipes.edges.is_empty() %}
-        <section>
-          <h3 class="text-[10px] font-semibold tracking-widest uppercase font-mono text-ink-3 mb-3">
-            {{ "Similar recipes"|t }}
-          </h3>
+        {# Similar recipes are loaded lazily via twinspark so they stay off the
+           page's critical render path. The skeleton below is swapped for the
+           fragment (or nothing, when there are no matches) once it arrives. #}
+        <div ts-trigger="load" ts-req="{{ "/r/"|demo_href }}{{ recipe.slug }}/similar">
+          <div class="h-2.5 w-24 shimmer mb-3"></div>
           <div class="space-y-3">
-            {% for similar_recipe in similar_recipes.edges.iter() %}
-              {% call suggestion_card(similar_recipe.node) %}{% endcall %}
+            {% for _ in 0..3 %}
+            <div class="flex gap-3">
+              <div class="w-32 h-20 rounded-xl shimmer shrink-0"></div>
+              <div class="flex-1 min-w-0 space-y-2 pt-1">
+                <div class="h-3.5 w-full shimmer"></div>
+                <div class="h-3 w-2/3 shimmer"></div>
+              </div>
+            </div>
             {% endfor %}
           </div>
-        </section>
-        {% endif %}
+        </div>
       </div>
     </aside>
 

--- a/web/demo/src/fixtures.rs
+++ b/web/demo/src/fixtures.rs
@@ -22,7 +22,7 @@ use imkitchen_web_grocery::{AisleSection, GroceriesTemplate};
 use imkitchen_web_kitchen::{CookingTemplate, KitchenTemplate, KitchenWeekDay};
 use imkitchen_web_menu::{MenuBoardDay, MenuSlot, MenuTemplate};
 use imkitchen_web_recipe::routes::cook::{CookTemplate, PageQuery as CookPageQuery};
-use imkitchen_web_recipe::routes::detail::DetailTemplate;
+use imkitchen_web_recipe::routes::detail::{DetailTemplate, SimilarTemplate};
 use imkitchen_web_recipe::routes::index::{IndexTemplate as RecipesIndexTemplate, PageQuery};
 use imkitchen_web_shared::auth::AuthUser;
 use time::{Duration, OffsetDateTime};
@@ -896,16 +896,6 @@ pub fn recipe_detail(id: &str) -> DetailTemplate<'static> {
     recipe.owner_name = Some("imkitchen".to_owned());
     recipe.is_shared = true;
 
-    let rt = recipe.recipe_type.0.clone();
-    let current_id = recipe.id.clone();
-
-    let similar_nodes: Vec<UserViewList> = catalog()
-        .iter()
-        .filter(|r| r.id != current_id && r.recipe_type.0 == rt)
-        .take(4)
-        .map(to_list)
-        .collect();
-
     DetailTemplate {
         user: demo_user(),
         recipe,
@@ -915,9 +905,30 @@ pub fn recipe_detail(id: &str) -> DetailTemplate<'static> {
             ..Default::default()
         },
         favorite: Favorite::default(),
-        similar_recipes: to_read_result(similar_nodes),
         owner_description: "Home cook sharing tried-and-tested family recipes.".to_owned(),
         ..Default::default()
+    }
+}
+
+/// Lazily-loaded "Similar recipes" fragment for the demo detail page — the
+/// twinspark counterpart to [`recipe_detail`], picking catalog recipes of the
+/// same type as the current one.
+pub fn recipe_similar(id: &str) -> SimilarTemplate {
+    let recipe =
+        find_recipe(id).unwrap_or_else(|| find_recipe("arroz-con-pollo").expect("seed recipe"));
+
+    let rt = recipe.recipe_type.0.clone();
+    let current_id = recipe.id.clone();
+
+    let similar_nodes: Vec<UserViewList> = catalog()
+        .iter()
+        .filter(|r| r.id != current_id && r.recipe_type.0 == rt)
+        .take(10)
+        .map(to_list)
+        .collect();
+
+    SimilarTemplate {
+        similar_recipes: to_read_result(similar_nodes),
     }
 }
 

--- a/web/demo/src/lib.rs
+++ b/web/demo/src/lib.rs
@@ -37,6 +37,7 @@ pub fn routes() -> axum::Router<AppState> {
         .route("/demo/recipes", get(recipes))
         .route("/demo/recipes/{id}", get(recipes_detail))
         .route("/demo/r/{slug}", get(recipes_detail))
+        .route("/demo/r/{slug}/similar", get(recipes_similar))
         .route("/demo/cooks/{username}", get(cooks))
         .route("/demo/groceries", get(groceries))
         .route("/demo/signup", get(signup_modal))
@@ -77,6 +78,20 @@ async fn recipes_detail(template: Template, Path((slug,)): Path<(String,)>) -> i
             .into_response()
     } else {
         Redirect::to(&format!("/r/{slug}")).into_response()
+    }
+}
+
+async fn recipes_similar(template: Template, Path((slug,)): Path<(String,)>) -> impl IntoResponse {
+    // Mirrors `recipes_detail`: fixture recipes render their similar rail from
+    // the demo catalog; any other slug is a real public recipe reached
+    // anonymously, so defer to the real fragment (which renders in demo mode).
+    if fixtures::find_recipe(&slug).is_some() {
+        template
+            .demo()
+            .render(fixtures::recipe_similar(&slug))
+            .into_response()
+    } else {
+        Redirect::to(&format!("/r/{slug}/similar")).into_response()
     }
 }
 

--- a/web/recipe/src/lib.rs
+++ b/web/recipe/src/lib.rs
@@ -46,6 +46,7 @@ pub fn routes() -> axum::Router<imkitchen_web_shared::AppState> {
         .route("/recipes/{id}/thumbnail", post(routes::thumbnail::upload))
         .route("/cooks/{username}", get(routes::cook::page))
         .route("/r/{slug}", get(routes::detail::page))
+        .route("/r/{slug}/similar", get(routes::detail::similar))
         .route("/recipes/{id}", get(routes::detail::redirect_to_slug))
         .route(
             "/recipes/_edit/ingredient-row",

--- a/web/recipe/src/routes/detail.rs
+++ b/web/recipe/src/routes/detail.rs
@@ -52,11 +52,19 @@ pub struct DetailTemplate<'a> {
     pub recipe: UserView,
     pub stat: UserStatView,
     pub favorite: favorite::Favorite,
-    pub similar_recipes: ReadResult<UserViewList>,
     pub owner_description: String,
     /// Pre-serialized schema.org/Recipe JSON-LD for search-engine rich
     /// results. Empty string renders no `<script>` (e.g. in demo mode).
     pub json_ld: String,
+}
+
+/// Right-rail "Similar recipes" fragment, lazily loaded via twinspark
+/// (`GET /r/{slug}/similar`) so the detail page returns its main content
+/// without waiting on the similar-recipes queries.
+#[derive(askama::Template)]
+#[template(path = "partials/recipes-similar.html")]
+pub struct SimilarTemplate {
+    pub similar_recipes: ReadResult<UserViewList>,
 }
 
 /// Builds a schema.org/Recipe JSON-LD document for a recipe. The `<`, `>` and
@@ -153,7 +161,6 @@ impl<'a> Default for DetailTemplate<'a> {
             user: AuthUser::default(),
             recipe: Default::default(),
             stat: UserStatView::default(),
-            similar_recipes: Default::default(),
             favorite: Default::default(),
             username: "john_doe",
             owner_description: String::new(),
@@ -221,6 +228,65 @@ pub async fn page(
     )
     .to_owned();
 
+    let owner_profile = imkitchen_web_shared::try_page_response!(
+        app.identity.user_profile.load(&recipe.owner_id),
+        template
+    );
+
+    let username = user.username();
+    // Structured data for search engines — only on the canonical public page
+    // (signed-in or guest), not the demo tour.
+    let json_ld = recipe_json_ld(&recipe, &app.config.server.url);
+
+    template
+        .render(DetailTemplate {
+            user,
+            recipe,
+            stat,
+            favorite,
+            username: username.as_str(),
+            owner_description: owner_profile.description,
+            json_ld,
+            ..Default::default()
+        })
+        .into_response()
+}
+
+/// Right-rail "Similar recipes" fragment, lazily loaded by the detail page via
+/// twinspark (`ts-trigger="load"`). Kept off the page's critical path because
+/// finding suggestions runs up to three fallback queries.
+#[tracing::instrument(skip_all)]
+pub async fn similar(
+    template: Template,
+    user: Option<AuthUser>,
+    Path((slug,)): Path<(String,)>,
+    State(app): State<AppState>,
+) -> impl IntoResponse {
+    // Resolve slug → id with the same id-fallback as `page` so legacy links work.
+    let id = match imkitchen_web_shared::try_page_response!(
+        app.core.recipe.find_id_by_slug(&slug),
+        template
+    ) {
+        Some(id) => id,
+        None => slug.clone(),
+    };
+    let recipe = imkitchen_web_shared::try_page_response!(opt: app.core.recipe.user(&id), template);
+
+    // Mirror the page's visibility + demo handling: only shared recipes (or the
+    // owner's own) are viewable, and anonymous visitors render in demo mode.
+    let is_anonymous = user.is_none();
+    let user = user.unwrap_or_else(AuthUser::demo);
+
+    if recipe.owner_id != user.id && !recipe.is_shared {
+        return template.render(NotFoundTemplate).into_response();
+    }
+
+    let template = if is_anonymous {
+        template.demo()
+    } else {
+        template
+    };
+
     let exclude_ids = vec![recipe.id.to_owned()];
 
     let mut similar_recipes = imkitchen_web_shared::try_page_response!(
@@ -233,14 +299,14 @@ pub async fn page(
             dietary_restrictions: recipe.dietary_restrictions.0.to_vec(),
             dietary_where_any: false,
             in_meal_plan: None,
-            sort_by: SortBy::RecentlyAdded,
-            args: Args::forward(6, None),
+            sort_by: SortBy::Random,
+            args: Args::forward(10, None),
             search: None,
         }),
         template
     );
 
-    if similar_recipes.edges.len() < 6 {
+    if similar_recipes.edges.len() < 10 {
         let mut similar_ids = similar_recipes
             .edges
             .iter()
@@ -258,8 +324,8 @@ pub async fn page(
                 dietary_restrictions: recipe.dietary_restrictions.0.to_vec(),
                 dietary_where_any: true,
                 in_meal_plan: None,
-                sort_by: SortBy::RecentlyAdded,
-                args: Args::forward(6, None),
+                sort_by: SortBy::Random,
+                args: Args::forward(10, None),
                 search: None,
             }),
             template
@@ -268,7 +334,7 @@ pub async fn page(
         similar_recipes.edges.extend(more_recipes.edges);
     }
 
-    if similar_recipes.edges.len() < 6 {
+    if similar_recipes.edges.len() < 10 {
         let mut similar_ids = similar_recipes
             .edges
             .iter()
@@ -286,8 +352,8 @@ pub async fn page(
                 dietary_restrictions: vec![],
                 dietary_where_any: false,
                 in_meal_plan: None,
-                sort_by: SortBy::RecentlyAdded,
-                args: Args::forward(6, None),
+                sort_by: SortBy::Random,
+                args: Args::forward(10, None),
                 search: None,
             }),
             template
@@ -296,28 +362,12 @@ pub async fn page(
         similar_recipes.edges.extend(more_recipes.edges);
     }
 
-    let owner_profile = imkitchen_web_shared::try_page_response!(
-        app.identity.user_profile.load(&recipe.owner_id),
-        template
-    );
-
-    let username = user.username();
-    // Structured data for search engines — only on the canonical public page
-    // (signed-in or guest), not the demo tour.
-    let json_ld = recipe_json_ld(&recipe, &app.config.server.url);
+    // Fallback tiers can overshoot the target; keep at most 10 (exact matches,
+    // which are collected first, take precedence).
+    similar_recipes.edges.truncate(10);
 
     template
-        .render(DetailTemplate {
-            user,
-            recipe,
-            stat,
-            similar_recipes,
-            favorite,
-            username: username.as_str(),
-            owner_description: owner_profile.description,
-            json_ld,
-            ..Default::default()
-        })
+        .render(SimilarTemplate { similar_recipes })
         .into_response()
 }
 


### PR DESCRIPTION
## Summary

Improves the recipe detail page (`/r/{slug}`) loading and freshens the **Similar recipes** rail.

- **Lazy-load the sidebar.** The "Similar recipes" rail is now a twinspark fragment (`GET /r/{slug}/similar`) triggered on `load`, so the main recipe content is no longer blocked on the suggestion queries (up to three fallback `filter_user` queries). A `shimmer` skeleton shows until it arrives. Mirrors the existing lazy-fragment pattern in `settings-billing.html`.
- **Show 10, randomized.** Raised the count from 6 → 10 and added a `SortBy::Random` ordering (`ORDER BY RANDOM()`, bypassing cursor pagination — same pattern as meal-plan generation). A recipe's suggestions now vary between page loads instead of always showing the same recent set. Result is truncated to 10 (exact dietary matches take precedence).
- **Demo parity.** New `/demo/r/{slug}/similar` fragment route + `fixtures::recipe_similar` so the demo tour and anonymous public views load the rail too.

## Verification

- `cargo build` (full workspace) and `cargo clippy` on core/recipe/demo pass clean.
- Manual: open a recipe whose type has >10 shared recipes — the rail shows up to 10 and refreshing changes which appear; a type with <10 fills via the fallback tiers; logged-out/demo views load the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)