### PR TITLE
perf(recipe): stop storing thumbnail image bytes in the event log

### DIFF
--- a/crates/core/src/recipe/query/thumbnail.rs
+++ b/crates/core/src/recipe/query/thumbnail.rs
@@ -4,8 +4,8 @@ use evento::{
     subscription::{Context, SubscriptionBuilder},
 };
 use imkitchen_db::recipe_thumbnail::RecipeThumbnail;
-use imkitchen_types::recipe::{Deleted, ThumbnailResized};
-use sea_query::{Expr, ExprTrait, OnConflict, Query, SqliteQueryBuilder};
+use imkitchen_types::recipe::Deleted;
+use sea_query::{Expr, ExprTrait, Query, SqliteQueryBuilder};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::prelude::FromRow;
 
@@ -44,44 +44,11 @@ impl<E: Executor> crate::recipe::Module<E> {
 }
 
 pub fn subscription<E: Executor>() -> SubscriptionBuilder<E> {
-    SubscriptionBuilder::new("recipe-thumbnail-view")
-        .handler(handle_resized())
-        .handler(handle_deleted())
-}
-
-#[evento::subscription]
-async fn handle_resized<E: Executor>(
-    context: &Context<'_, E>,
-    event: Event<ThumbnailResized>,
-) -> anyhow::Result<()> {
-    let pool = context.extract::<sqlx::SqlitePool>();
-
-    let statement = Query::insert()
-        .into_table(RecipeThumbnail::Table)
-        .columns([
-            RecipeThumbnail::Id,
-            RecipeThumbnail::Device,
-            RecipeThumbnail::Data,
-        ])
-        .values_panic([
-            event.aggregate_id.to_owned().into(),
-            event.data.device.to_owned().into(),
-            event.data.data.into(),
-        ])
-        .on_conflict(
-            OnConflict::columns([RecipeThumbnail::Id, RecipeThumbnail::Device])
-                .update_column(RecipeThumbnail::Data)
-                .to_owned(),
-        )
-        .to_owned();
-
-    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
-
-    sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
-        .execute(&pool)
-        .await?;
-
-    Ok(())
+    // Resized variant bytes are now written directly to recipe_thumbnail by the
+    // "recipe-command" resize subscription (the authoritative image store), so
+    // there is no longer a ThumbnailResized handler here. This view only needs
+    // to clean up on deletion.
+    SubscriptionBuilder::new("recipe-thumbnail-view").handler(handle_deleted())
 }
 
 #[evento::subscription]
@@ -91,6 +58,9 @@ async fn handle_deleted<E: Executor>(
 ) -> anyhow::Result<()> {
     let pool = context.extract::<sqlx::SqlitePool>();
 
+    // No device filter on purpose: this removes every variant for the recipe,
+    // including any transient device='original' row left behind if the process
+    // died mid-resize.
     let statement = Query::delete()
         .from_table(RecipeThumbnail::Table)
         .and_where(Expr::col(RecipeThumbnail::Id).eq(&event.aggregate_id))

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -7,6 +7,7 @@ use evento::{
 };
 use image::imageops::FilterType;
 use imkitchen_db::mealplan_recipe::MealPlanRecipe;
+use imkitchen_db::recipe_thumbnail::RecipeThumbnail;
 use imkitchen_db::recipe_user::{RecipeUser, RecipeUserFts};
 use imkitchen_types::recipe::{
     AdvancePrepChanged, BasicInformationChanged, Created, Deleted, DietaryRestriction,
@@ -550,6 +551,19 @@ impl<E: Executor> Snapshot<E> for UserView {
 
         let slug = build_slug(&write_db, &self.id, &self.name).await?;
 
+        // The blur placeholder is invalidated (set to None) by the mobile
+        // ThumbnailResized handler because handlers have no DB access. Recompute
+        // it here once from the authoritative recipe_thumbnail mobile variant,
+        // which the resize subscription has already written. If it is already
+        // Some (loaded via restore from a prior snapshot) keep it as-is.
+        let blur_placeholder = match &self.blur_placeholder {
+            Some(blur) => Some(blur.to_owned()),
+            None if self.thumbnail_version.is_some() => {
+                read_mobile_blur(&write_db, &self.id).await?
+            }
+            None => None,
+        };
+
         let ingredients = bitcode::encode(&self.ingredients.0);
         let instructions = bitcode::encode(&self.instructions.0);
         let difficulty_score: u16 =
@@ -608,7 +622,7 @@ impl<E: Executor> Snapshot<E> for UserView {
                 difficulty_score.into(),
                 self.created_at.into(),
                 self.thumbnail_version.to_owned().into(),
-                self.blur_placeholder.to_owned().into(),
+                blur_placeholder.into(),
             ])?
             .on_conflict(
                 OnConflict::column(RecipeUser::Id)
@@ -797,13 +811,33 @@ async fn handle_thumbnail_resized(
 ) -> anyhow::Result<()> {
     data.thumbnail_version = Some(event.id.to_string());
 
-    // Derive a tiny blurred base64 placeholder (LQIP) from the mobile variant only,
-    // so it is generated once per upload rather than once per device.
+    // The event no longer carries image bytes, and evento handlers have no DB
+    // access, so the blur placeholder can't be computed here. Invalidate it on
+    // the mobile marker; take_snapshot recomputes it once from the authoritative
+    // recipe_thumbnail mobile variant (generated once per upload, not per device).
     if event.data.device == "mobile" {
-        data.blur_placeholder = build_blur_placeholder(&event.data.data);
+        data.blur_placeholder = None;
     }
 
     Ok(())
+}
+
+/// Load the mobile thumbnail variant from the authoritative `recipe_thumbnail`
+/// store and derive its blur placeholder. Returns `None` if the row is missing
+/// or the bytes cannot be decoded.
+async fn read_mobile_blur(pool: &SqlitePool, id: &str) -> anyhow::Result<Option<String>> {
+    let statement = Query::select()
+        .column(RecipeThumbnail::Data)
+        .from(RecipeThumbnail::Table)
+        .and_where(Expr::col(RecipeThumbnail::Id).eq(id))
+        .and_where(Expr::col(RecipeThumbnail::Device).eq("mobile"))
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+    let bytes = sqlx::query_scalar_with::<_, Vec<u8>, _>(sqlx::AssertSqlSafe(sql), values)
+        .fetch_optional(pool)
+        .await?;
+
+    Ok(bytes.as_deref().and_then(build_blur_placeholder))
 }
 
 /// Downscale the given WebP thumbnail to a tiny blurred base64 data URL used as a

--- a/crates/core/src/recipe/root/mod.rs
+++ b/crates/core/src/recipe/root/mod.rs
@@ -5,6 +5,7 @@ use evento::{
     subscription::{Context, SubscriptionBuilder},
 };
 use image::imageops::FilterType;
+use imkitchen_db::recipe_thumbnail::RecipeThumbnail;
 use imkitchen_types::recipe::{
     self, AdvancePrepChanged, BasicInformationChanged, Created, CuisineTypeChanged, Deleted,
     DietaryRestrictionsChanged, Imported, IngredientsChanged, InstructionsChanged, MadePrivate,
@@ -12,6 +13,8 @@ use imkitchen_types::recipe::{
     ThumbnailUploaded,
 };
 use imkitchen_types::recipe_share::{self, AllMadePrivate, AllSharedToCommunity};
+use sea_query::{Expr, ExprTrait, OnConflict, Query as SeaQuery, SqliteQueryBuilder};
+use sea_query_sqlx::SqlxBinder;
 use sha3::{Digest, Sha3_224};
 use std::ops::Deref;
 use webp::Encoder;
@@ -356,36 +359,117 @@ async fn handle_thumbnail_uploaded<E: Executor>(
     context: &Context<'_, E>,
     event: Event<ThumbnailUploaded>,
 ) -> anyhow::Result<()> {
+    let (read_db, write_db) = context.extract::<(sqlx::SqlitePool, sqlx::SqlitePool)>();
+
+    // Load the transient original stashed by the upload command. If it is
+    // absent this is an idempotent replay (the original was already consumed
+    // and deleted); the resized variants are authoritative in recipe_thumbnail,
+    // so there is nothing to do.
+    let Some(original) = load_original(&read_db, &event.aggregate_id).await? else {
+        tracing::debug!(
+            id = %event.aggregate_id,
+            "recipe-command.handle_thumbnail_uploaded.original_absent"
+        );
+        return Ok(());
+    };
+
+    let img = match image::load_from_memory(&original) {
+        Ok(img) => img,
+        Err(err) => {
+            tracing::warn!(error = ?err, "recipe-command.handle_thumbnail_uploaded.load_from_memory");
+            // Drop the unusable original so it does not linger.
+            delete_original(&write_db, &event.aggregate_id).await?;
+            return Ok(());
+        }
+    };
+
     let original_version = context
         .executor
         .original_version::<ThumbnailResized>(&event.aggregate_id)
         .await?
         .expect("aggregator exist");
-    let img = match image::load_from_memory(&event.data.data) {
-        Ok(img) => img,
-        Err(err) => {
-            tracing::warn!(error = ?err, "recipe-command.handle_thumbnail_uploaded.load_from_memory");
-
-            return Ok(());
-        }
-    };
     let mut builder = evento::append(&event.aggregate_id)
         .original_version(original_version)
         .metadata_from(&event.metadata)
         .to_owned();
 
     for (name, width, quality) in IMAGE_VARIANTS {
-        let resized = img.resize(*width, u32::MAX, FilterType::Lanczos3);
-        let rgba = resized.to_rgba8();
+        // Scope the encode so the non-Send WebPMemory/Encoder are dropped before
+        // the await below; only the owned Vec<u8> crosses the await point.
+        let webp: Vec<u8> = {
+            let resized = img.resize(*width, u32::MAX, FilterType::Lanczos3);
+            let rgba = resized.to_rgba8();
+            let encoder = Encoder::from_rgba(rgba.as_raw(), rgba.width(), rgba.height());
+            encoder.encode(*quality).to_vec() // 0.0 - 100.0
+        };
 
-        let encoder = Encoder::from_rgba(rgba.as_raw(), rgba.width(), rgba.height());
+        // Authoritative write of the variant bytes. recipe_thumbnail is now the
+        // source of truth for images; the event carries no bytes.
+        upsert_variant(&write_db, &event.aggregate_id, name, webp).await?;
 
-        let webp = encoder.encode(*quality); // 0.0 - 100.0
+        // Byte-free marker so the version/blur projections react.
         builder.event(&ThumbnailResized {
             device: name.to_string(),
-            data: webp.to_vec(),
         });
     }
     builder.commit(context.executor).await?;
+
+    // Variants are persisted; drop the transient original.
+    delete_original(&write_db, &event.aggregate_id).await?;
+    Ok(())
+}
+
+async fn load_original(pool: &sqlx::SqlitePool, id: &str) -> anyhow::Result<Option<Vec<u8>>> {
+    let statement = SeaQuery::select()
+        .column(RecipeThumbnail::Data)
+        .from(RecipeThumbnail::Table)
+        .and_where(Expr::col(RecipeThumbnail::Id).eq(id))
+        .and_where(Expr::col(RecipeThumbnail::Device).eq("original"))
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+    Ok(
+        sqlx::query_scalar_with::<_, Vec<u8>, _>(sqlx::AssertSqlSafe(sql), values)
+            .fetch_optional(pool)
+            .await?,
+    )
+}
+
+async fn upsert_variant(
+    pool: &sqlx::SqlitePool,
+    id: &str,
+    device: &str,
+    data: Vec<u8>,
+) -> anyhow::Result<()> {
+    let statement = SeaQuery::insert()
+        .into_table(RecipeThumbnail::Table)
+        .columns([
+            RecipeThumbnail::Id,
+            RecipeThumbnail::Device,
+            RecipeThumbnail::Data,
+        ])
+        .values_panic([id.into(), device.into(), data.into()])
+        .on_conflict(
+            OnConflict::columns([RecipeThumbnail::Id, RecipeThumbnail::Device])
+                .update_column(RecipeThumbnail::Data)
+                .to_owned(),
+        )
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+    sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn delete_original(pool: &sqlx::SqlitePool, id: &str) -> anyhow::Result<()> {
+    let statement = SeaQuery::delete()
+        .from_table(RecipeThumbnail::Table)
+        .and_where(Expr::col(RecipeThumbnail::Id).eq(id))
+        .and_where(Expr::col(RecipeThumbnail::Device).eq("original"))
+        .to_owned();
+    let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+    sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
+        .execute(pool)
+        .await?;
     Ok(())
 }

--- a/crates/core/src/recipe/root/upload_thumbnail.rs
+++ b/crates/core/src/recipe/root/upload_thumbnail.rs
@@ -1,5 +1,8 @@
 use evento::{Executor, ProjectionAggregate};
+use imkitchen_db::recipe_thumbnail::RecipeThumbnail;
 use imkitchen_types::recipe::ThumbnailUploaded;
+use sea_query::{OnConflict, Query, SqliteQueryBuilder};
+use sea_query_sqlx::SqlxBinder;
 
 impl<E: Executor + Clone> super::Module<E> {
     pub async fn upload_thumbnail(
@@ -21,9 +24,34 @@ impl<E: Executor + Clone> super::Module<E> {
             crate::user!("{err}");
         };
 
+        // Stash the original transiently in recipe_thumbnail (device='original')
+        // so the async resize subscription can read it without the bytes ever
+        // entering the event log. The row is deleted by the resize handler once
+        // the variants are produced. Written before the event is committed so
+        // the subscription is guaranteed to see it.
+        let statement = Query::insert()
+            .into_table(RecipeThumbnail::Table)
+            .columns([
+                RecipeThumbnail::Id,
+                RecipeThumbnail::Device,
+                RecipeThumbnail::Data,
+            ])
+            .values_panic([recipe.id.to_owned().into(), "original".into(), data.into()])
+            .on_conflict(
+                OnConflict::columns([RecipeThumbnail::Id, RecipeThumbnail::Device])
+                    .update_column(RecipeThumbnail::Data)
+                    .to_owned(),
+            )
+            .to_owned();
+
+        let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+        sqlx::query_with(sqlx::AssertSqlSafe(sql), values)
+            .execute(&self.write_db)
+            .await?;
+
         recipe
             .write()?
-            .event(&ThumbnailUploaded { data })
+            .event(&ThumbnailUploaded)
             .requested_by(request_by)
             .commit(&self.executor)
             .await?;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod m0005;
 pub(crate) mod m0006;
 pub(crate) mod m0007;
 pub(crate) mod m0008;
+pub(crate) mod m0009;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
@@ -44,6 +45,7 @@ where
     m0006::Migration: sqlx_migrator::Migration<DB>,
     m0007::Migration: sqlx_migrator::Migration<DB>,
     m0008::Migration: sqlx_migrator::Migration<DB>,
+    m0009::Migration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = evento::sql_migrator::new::<DB>()?;
     migrator.add_migrations(vec![
@@ -55,6 +57,7 @@ where
         Box::new(m0006::Migration),
         Box::new(m0007::Migration),
         Box::new(m0008::Migration),
+        Box::new(m0009::Migration),
     ])?;
 
     Ok(migrator)

--- a/crates/db/src/m0009/mod.rs
+++ b/crates/db/src/m0009/mod.rs
@@ -1,0 +1,11 @@
+use sqlx_migrator::vec_box;
+
+pub struct Migration;
+
+sqlx_migrator::sqlite_migration!(
+    Migration,
+    "imkitchen",
+    "m0009",
+    vec_box![super::m0008::Migration],
+    vec_box![crate::recipe_thumbnail::m0009::StripThumbnailBytes]
+);

--- a/crates/db/src/recipe_thumbnail.rs
+++ b/crates/db/src/recipe_thumbnail.rs
@@ -117,3 +117,83 @@ pub(crate) mod m0001 {
         }
     }
 }
+
+pub(crate) mod m0009 {
+    /// One-time reclaim: strip the image bytes out of the thumbnail events.
+    ///
+    /// Historically `ThumbnailUploaded` carried the original upload bytes and
+    /// `ThumbnailResized` carried the resized WebP bytes, so every image lived
+    /// three times (both events plus the `recipe_thumbnail` projection). The
+    /// event format is now byte-free (`ThumbnailUploaded` is a unit variant and
+    /// `ThumbnailResized` only keeps `device`), and `recipe_thumbnail` is the
+    /// authoritative image store.
+    ///
+    /// The rewrite is done in pure SQL because the new bitcode blob is a prefix
+    /// of the old one (verified against every row): a unit variant encodes to an
+    /// empty blob, and `ThumbnailResized { device }` encodes to just the leading
+    /// length-prefixed device string. `substr` on a BLOB operates byte-wise.
+    ///
+    /// IRREVERSIBLE: the original upload bytes are discarded and are not stored
+    /// anywhere else, so `down()` cannot restore them.
+    pub struct StripThumbnailBytes;
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for StripThumbnailBytes {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // Guard: the byte-slice rewrite only handles the known device
+            // prefixes 0x06 ("mobile"/"tablet") and 0x07 ("desktop"). Abort if
+            // anything else exists so we never truncate to the wrong length.
+            let unexpected: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM event \
+                 WHERE name = 'ThumbnailResized' \
+                 AND substr(data, 1, 1) NOT IN (X'06', X'07')",
+            )
+            .fetch_one(&mut *connection)
+            .await?;
+
+            if unexpected != 0 {
+                return Err(sqlx_migrator::Error::Box(Box::from(format!(
+                    "m0009: {unexpected} ThumbnailResized events have an unexpected \
+                     device prefix; aborting to avoid corrupting event data"
+                ))));
+            }
+
+            // ThumbnailUploaded is now a unit variant → empty blob.
+            sqlx::query("UPDATE event SET data = X'' WHERE name = 'ThumbnailUploaded'")
+                .execute(&mut *connection)
+                .await?;
+
+            // ThumbnailResized { device } → keep only the length-prefixed device
+            // string, dropping the trailing Vec<u8>. mobile/tablet = 6-char
+            // device (prefix 0x06) → keep 7 bytes; desktop = 7-char (0x07) → 8.
+            sqlx::query(
+                "UPDATE event \
+                 SET data = CASE substr(data, 1, 1) \
+                              WHEN X'06' THEN substr(data, 1, 7) \
+                              WHEN X'07' THEN substr(data, 1, 8) \
+                            END \
+                 WHERE name = 'ThumbnailResized'",
+            )
+            .execute(&mut *connection)
+            .await?;
+
+            // Do NOT reset the recipe-thumbnail-view / recipe-query cursors or
+            // truncate recipe_thumbnail: the variant bytes and the existing
+            // blur_placeholder values are authoritative and can no longer be
+            // rebuilt from events.
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            _connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // Irreversible: the stripped image bytes were discarded. No-op,
+            // matching the precedent for irreversible data migrations.
+            Ok(())
+        }
+    }
+}

--- a/crates/types/src/recipe.rs
+++ b/crates/types/src/recipe.rs
@@ -265,15 +265,66 @@ pub enum Recipe {
         owner_name: String,
     },
 
-    ThumbnailUploaded {
-        data: Vec<u8>,
-    },
+    // Byte-free trigger. The original upload bytes are stashed transiently in
+    // `recipe_thumbnail` (device='original') by the upload command and consumed
+    // by the resize subscription, so no image bytes ever enter the event log.
+    ThumbnailUploaded,
 
+    // Byte-free marker. The resized variant bytes are written directly to
+    // `recipe_thumbnail` (the authoritative image store); this event only
+    // signals which device variant was (re)generated so downstream version and
+    // blur-placeholder projections can react.
     ThumbnailResized {
         device: String,
-        data: Vec<u8>,
     },
 
     MadePrivate,
     Deleted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ThumbnailResized, ThumbnailUploaded};
+
+    // The m0009 data migration strips image bytes out of existing thumbnail
+    // event blobs with pure SQL, relying on the fact that the new byte-free
+    // bitcode encoding is a *prefix* of the old one: a unit `ThumbnailUploaded`
+    // encodes to an empty blob, and `ThumbnailResized { device }` encodes to
+    // just the length-prefixed device string. If a bitcode upgrade ever changes
+    // this layout, the migration's byte-slicing would silently corrupt data, so
+    // pin the exact bytes here.
+    #[test]
+    fn thumbnail_uploaded_encodes_empty() {
+        assert!(bitcode::encode(&ThumbnailUploaded).is_empty());
+    }
+
+    #[test]
+    fn thumbnail_resized_encodes_to_device_prefix() {
+        // 0x06 = len("mobile"), then the utf8 bytes — matches substr(data,1,7).
+        assert_eq!(
+            bitcode::encode(&ThumbnailResized {
+                device: "mobile".to_string(),
+            }),
+            b"\x06mobile",
+        );
+        assert_eq!(
+            bitcode::encode(&ThumbnailResized {
+                device: "tablet".to_string(),
+            }),
+            b"\x06tablet",
+        );
+        // 0x07 = len("desktop") — matches substr(data,1,8).
+        assert_eq!(
+            bitcode::encode(&ThumbnailResized {
+                device: "desktop".to_string(),
+            }),
+            b"\x07desktop",
+        );
+    }
+
+    #[test]
+    fn stripped_resized_blob_decodes() {
+        let decoded: ThumbnailResized = bitcode::decode(b"\x06mobile").unwrap();
+        assert_eq!(decoded.device, "mobile");
+    }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -26,6 +26,24 @@ pub async fn migrate(config: imkitchen_web_shared::config::Config) -> Result<()>
         .await?;
     drop(conn);
 
+    // Reclaim free pages left behind by data migrations that shrink rows (e.g.
+    // m0009 stripping ~1.9GB of image bytes out of the event log). VACUUM
+    // rewrites the whole file and cannot run inside the migration transaction,
+    // so it runs here on a fresh connection. Gate it on the freelist so routine
+    // deploys with nothing to reclaim don't pay the cost.
+    let mut conn = pool.acquire().await?;
+    let freelist: i64 = sqlx::query_scalar("PRAGMA freelist_count")
+        .fetch_one(&mut *conn)
+        .await?;
+    if freelist > 0 {
+        tracing::info!("Reclaiming {freelist} free pages (VACUUM)...");
+        sqlx::query("VACUUM").execute(&mut *conn).await?;
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&mut *conn)
+            .await?;
+    }
+    drop(conn);
+
     tracing::info!("Migrations completed successfully");
 
     Ok(())

--- a/web/admin/tests/thumbnail.rs
+++ b/web/admin/tests/thumbnail.rs
@@ -1,0 +1,189 @@
+use std::io::Cursor;
+use std::str::FromStr;
+
+use evento::Sqlite;
+use evento::migrator::{Migrate, Plan};
+use image::{DynamicImage, ImageFormat, RgbImage};
+use imkitchen_core::State;
+use sqlx::{SqlitePool, sqlite::SqliteConnectOptions};
+use temp_dir::TempDir;
+
+async fn setup_test_state(path: std::path::PathBuf) -> anyhow::Result<State<Sqlite>> {
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite:{}", path.to_str().unwrap()))?
+        .create_if_missing(true);
+    let pool = SqlitePool::connect_with(opts).await?;
+    let mut conn = pool.acquire().await?;
+    imkitchen_db::migrator::<sqlx::Sqlite>()?
+        .run(&mut conn, &Plan::apply_all())
+        .await?;
+
+    Ok(State {
+        executor: pool.clone().into(),
+        read_db: pool.clone(),
+        write_db: pool,
+    })
+}
+
+fn png_bytes() -> Vec<u8> {
+    let img = RgbImage::new(4, 4);
+    let mut out = Cursor::new(Vec::new());
+    DynamicImage::ImageRgb8(img)
+        .write_to(&mut out, ImageFormat::Png)
+        .unwrap();
+    out.into_inner()
+}
+
+/// Uploading a thumbnail must stash the original bytes transiently in
+/// recipe_thumbnail (device='original') for the async resizer, and the
+/// committed ThumbnailUploaded event must carry no image bytes.
+#[tokio::test]
+async fn upload_thumbnail_stashes_original_and_emits_byte_free_event() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let state = setup_test_state(dir.child("db.sqlite3")).await?;
+    let recipe = imkitchen_core::recipe::Module::new(state.clone());
+
+    let id = recipe.create("chef-1", None).await?;
+
+    let png = png_bytes();
+    recipe.upload_thumbnail(&id, png.clone(), "chef-1").await?;
+
+    // The original is stashed under device='original' with the exact bytes.
+    let original: Option<Vec<u8>> = sqlx::query_scalar(
+        "SELECT data FROM recipe_thumbnail WHERE id = ? AND device = 'original'",
+    )
+    .bind(&id)
+    .fetch_optional(&state.read_db)
+    .await?;
+    assert_eq!(original.as_deref(), Some(png.as_slice()));
+
+    // The ThumbnailUploaded event exists but carries no image bytes.
+    let uploaded_len: Option<i64> = sqlx::query_scalar(
+        "SELECT length(data) FROM event WHERE aggregator_id = ? AND name = 'ThumbnailUploaded'",
+    )
+    .bind(&id)
+    .fetch_optional(&state.read_db)
+    .await?;
+    assert_eq!(uploaded_len, Some(0), "event must be byte-free");
+
+    Ok(())
+}
+
+/// Full async pipeline: upload -> resize subscription writes the three variants
+/// to recipe_thumbnail (authoritative), emits byte-free ThumbnailResized
+/// markers, deletes the transient original; the user projection derives the
+/// blur placeholder from the stored mobile variant.
+#[tokio::test]
+async fn resize_pipeline_writes_variants_and_blur_without_event_bytes() -> anyhow::Result<()> {
+    let dir = TempDir::new()?;
+    let path = dir.child("db.sqlite3");
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite:{}", path.to_str().unwrap()))?
+        .create_if_missing(true);
+    let pool = SqlitePool::connect_with(opts).await?;
+    {
+        let mut conn = pool.acquire().await?;
+        imkitchen_db::migrator::<sqlx::Sqlite>()?
+            .run(&mut conn, &Plan::apply_all())
+            .await?;
+    }
+
+    let rw: evento::sql::RwSqlite = (
+        evento::Sqlite::from(pool.clone()),
+        evento::Sqlite::from(pool.clone()),
+    )
+        .into();
+    let executor = evento::Evento::new(rw);
+
+    // Mirror server.rs wiring for the three recipe subscriptions.
+    let _sub_command = imkitchen_core::recipe::subscription()
+        .data((pool.clone(), pool.clone()))
+        .start(&executor)
+        .await?;
+    let _sub_query = imkitchen_core::recipe::query::user::create_projection()
+        .data((pool.clone(), pool.clone()))
+        .subscription("recipe-query")
+        .all()
+        .start(&executor)
+        .await?;
+    let _sub_thumbnail = imkitchen_core::recipe::query::thumbnail::subscription()
+        .data(pool.clone())
+        .all()
+        .start(&executor)
+        .await?;
+
+    let state = State {
+        executor: executor.clone(),
+        read_db: pool.clone(),
+        write_db: pool.clone(),
+    };
+    let recipe = imkitchen_core::recipe::Module::new(state);
+
+    let id = recipe.create("chef-1", None).await?;
+    recipe.upload_thumbnail(&id, png_bytes(), "chef-1").await?;
+
+    // Poll until the async resize subscription has produced the three variants.
+    let mut variants: Vec<String> = Vec::new();
+    for _ in 0..100 {
+        variants = sqlx::query_scalar(
+            "SELECT device FROM recipe_thumbnail WHERE id = ? AND device <> 'original' ORDER BY device",
+        )
+        .bind(&id)
+        .fetch_all(&pool)
+        .await?;
+        if variants.len() == 3 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        variants,
+        vec![
+            "desktop".to_string(),
+            "mobile".to_string(),
+            "tablet".to_string()
+        ],
+        "all three device variants written to recipe_thumbnail"
+    );
+
+    // The transient original is cleaned up.
+    let original: Option<Vec<u8>> = sqlx::query_scalar(
+        "SELECT data FROM recipe_thumbnail WHERE id = ? AND device = 'original'",
+    )
+    .bind(&id)
+    .fetch_optional(&pool)
+    .await?;
+    assert!(original.is_none(), "transient original must be deleted");
+
+    // ThumbnailResized markers carry only the device string (no image bytes):
+    // 7 bytes for mobile/tablet, 8 for desktop.
+    let bad_len: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM event WHERE aggregator_id = ? AND name = 'ThumbnailResized' AND length(data) NOT IN (7, 8)",
+    )
+    .bind(&id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(
+        bad_len, 0,
+        "ThumbnailResized events must be byte-free markers"
+    );
+
+    // The user projection derived a blur placeholder from the mobile variant.
+    let mut blur: Option<String> = None;
+    for _ in 0..100 {
+        blur = sqlx::query_scalar("SELECT blur_placeholder FROM recipe_user WHERE id = ?")
+            .bind(&id)
+            .fetch_optional(&pool)
+            .await?
+            .flatten();
+        if blur.is_some() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let blur = blur.expect("blur placeholder derived from the stored mobile variant");
+    assert!(
+        blur.starts_with("data:image/webp;base64,"),
+        "blur placeholder is a webp data URL, got: {blur}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Thumbnail images were persisted **three times**, accounting for ~95% of a 3.0 GB production database:

| Location | Size | Note |
|---|---|---|
| `event` → `ThumbnailResized` (13,737 rows) | ~1.19 GB | resized WebP bytes in the event payload |
| `event` → `ThumbnailUploaded` (4,579 rows) | ~0.73 GB | original upload bytes in the event payload |
| `recipe_thumbnail` (12,264 rows) | ~1.00 GB | the 3 resized variants (already complete) |

Because events are append-only, this triplication grows forever and bloats every replay, backup and WAL sync.

## Change

Make `recipe_thumbnail` the **single authoritative image store** and keep the event log byte-free.

- **Event format** — `ThumbnailUploaded` is now a unit variant; `ThumbnailResized` keeps only `device`.
- **Upload flow** — the command stashes the original transiently in `recipe_thumbnail` (`device='original'`) and emits a byte-free `ThumbnailUploaded`. The async resize subscription reads it, writes the 3 variants directly to the table, emits byte-free markers, then deletes the original (idempotent on replay).
- **Blur placeholder** — recomputed once from the stored mobile variant in `take_snapshot` (evento `#[handler]`s have no DB access).
- **Migration `m0009`** — strips bytes from existing thumbnail event blobs with **pure-SQL byte-slicing**. The new bitcode encoding is a *prefix* of the old one (verified against every row), so no decode or new deps are needed; guarded against unexpected device prefixes. **Irreversible** — the discarded original bytes cannot be restored.
- **`migrate` command** — `VACUUM`s when there are free pages to reclaim (gated on `freelist_count`), so the file actually shrinks after the strip.

## Verification

- `make fmt-check`, `make lint` (`-D warnings`), `make machete` — all clean.
- New byte-format regression tests pin the exact bitcode layout the migration relies on and confirm stripped blobs decode.
- **Migration run on a copy of the real 3.0 GB DB**: `ThumbnailUploaded` → 0 bytes, `ThumbnailResized` → 7/8 bytes, `recipe_thumbnail` intact, no leftover `original` rows, **file 3.02 GB → 1.09 GB** (~1.94 GB reclaimed).
- New end-to-end tests (`web/admin/tests/thumbnail.rs`): the upload write-path, and the full async pipeline (variants written, original cleaned up, byte-free markers, blur derived from the stored mobile variant).

## Notes / operational

- **Architectural invariant**: `recipe_thumbnail` must never again be truncated-and-rebuilt from events — image bytes are no longer derivable from the log. Documented in code.
- First deploy's `VACUUM` rewrites the whole file (~36 s on 3 GB in testing) and needs ~1× DB free disk + a generous init-container timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)