### PR TITLE
chore(helm): run litestream containers as non-root uid 10001

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: imkitchen
 description: Helm chart for the imkitchen server
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "1.5.0"
 home: https://imkitchen.app
 sources:

--- a/helm/templates/statefullset.yaml
+++ b/helm/templates/statefullset.yaml
@@ -33,6 +33,13 @@ spec:
         - name: litestream-restore
           image: {{ .Values.litestream.image | quote }}
           imagePullPolicy: IfNotPresent
+          # The litestream image runs as root by default; the pod enforces runAsNonRoot.
+          # Run as uid/gid 10001 (matches fsGroup) so it satisfies the policy and can
+          # read/write the SQLite files the app owns.
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            allowPrivilegeEscalation: false
           command:
             ["litestream", "restore", "-if-db-not-exists", "-if-replica-exists", "-config", "/etc/litestream/litestream.yml", "/var/lib/imkitchen/db.sqlite3"]
           volumeMounts:
@@ -71,6 +78,11 @@ spec:
           image: {{ .Values.litestream.image | quote }}
           imagePullPolicy: IfNotPresent
           restartPolicy: Always
+          # See litestream-restore: run as non-root uid/gid 10001 (matches fsGroup).
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            allowPrivilegeEscalation: false
           command:
             ["litestream", "replicate", "-config", "/etc/litestream/litestream.yml"]
           volumeMounts:


### PR DESCRIPTION
## Problem
With `litestream.enabled: true`, the pod fails to start:

```
Error: container has runAsNonRoot and image will run as root
(container: litestream-restore)
```

The pod's securityContext enforces `runAsNonRoot: true` (the app image bakes in uid 10001). The `litestream/litestream` image runs as **root** by default and sets no `runAsUser`, so kubelet rejects both litestream containers.

## Fix
Add a container-level `securityContext` to `litestream-restore` and the `litestream` sidecar:
```yaml
securityContext:
  runAsUser: 10001
  runAsGroup: 10001
  allowPrivilegeEscalation: false
```
uid/gid **10001** matches the pod `fsGroup`, so litestream satisfies the non-root policy **and** can read/write the app-owned SQLite files (db + WAL). Chart bumped `0.1.17 → 0.1.18`.

Verified with `helm template` (both containers render the securityContext) and `helm lint`.

> Deploy note: the imkitchen HelmRelease tracks the imkitchen repo `main` branch, so this needs to merge to `main` for Flux to pick it up and unblock the running `imkitchen-deployment-0` pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)