### PR TITLE
fix(recipe): write IngredientsChanged to FTS ingredients column

### DIFF
--- a/crates/core/src/recipe/query/user_fts.rs
+++ b/crates/core/src/recipe/query/user_fts.rs
@@ -132,7 +132,7 @@ async fn handle_ingredients_changed<E: Executor>(
             "recipe_user_fts = ?",
             [event.aggregate_id.to_owned()],
         ))
-        .value(RecipeUserFts::Name, ingredients)
+        .value(RecipeUserFts::Ingredients, ingredients)
         .build_sqlx(SqliteQueryBuilder);
 
     sqlx::query_with(sqlx::AssertSqlSafe(sql), values)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod m0006;
 pub(crate) mod m0007;
 pub(crate) mod m0008;
 pub(crate) mod m0009;
+pub(crate) mod m0010;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
@@ -46,6 +47,7 @@ where
     m0007::Migration: sqlx_migrator::Migration<DB>,
     m0008::Migration: sqlx_migrator::Migration<DB>,
     m0009::Migration: sqlx_migrator::Migration<DB>,
+    m0010::Migration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = evento::sql_migrator::new::<DB>()?;
     migrator.add_migrations(vec![
@@ -58,6 +60,7 @@ where
         Box::new(m0007::Migration),
         Box::new(m0008::Migration),
         Box::new(m0009::Migration),
+        Box::new(m0010::Migration),
     ])?;
 
     Ok(migrator)

--- a/crates/db/src/m0010/mod.rs
+++ b/crates/db/src/m0010/mod.rs
@@ -1,0 +1,11 @@
+use sqlx_migrator::vec_box;
+
+pub struct Migration;
+
+sqlx_migrator::sqlite_migration!(
+    Migration,
+    "imkitchen",
+    "m0010",
+    vec_box![super::m0009::Migration],
+    vec_box![crate::recipe_user::m0010::RebuildFts]
+);

--- a/crates/db/src/recipe_user.rs
+++ b/crates/db/src/recipe_user.rs
@@ -657,6 +657,53 @@ pub(crate) mod m0005 {
     }
 }
 
+pub(crate) mod m0010 {
+    use sea_query::{DeleteStatement, Query};
+
+    use super::RecipeUserFts;
+
+    pub struct RebuildFts;
+
+    // SQLite has no TRUNCATE — an unqualified DELETE triggers SQLite's truncate
+    // optimization (sqlite.org/lang_delete.html). On other backends sea-query
+    // will render the equivalent DELETE.
+    fn truncate_fts() -> DeleteStatement {
+        Query::delete().from_table(RecipeUserFts::Table).to_owned()
+    }
+
+    #[async_trait::async_trait]
+    impl sqlx_migrator::Operation<sqlx::Sqlite> for RebuildFts {
+        async fn up(
+            &self,
+            connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            // `handle_ingredients_changed` previously wrote the ingredient list
+            // into the FTS `name` column instead of `ingredients`, corrupting the
+            // index. Truncate the projection and reset its subscription cursor so
+            // the corrected handlers replay every event and rebuild it.
+            let truncate = truncate_fts().to_string(sea_query::SqliteQueryBuilder);
+            sqlx::query(sqlx::AssertSqlSafe(truncate))
+                .execute(&mut *connection)
+                .await?;
+
+            // `subscriber` is evento's internal table with no `Iden`, so the reset
+            // is raw SQL — the same way m0002/m0004/m0005/m0007 touch it.
+            sqlx::query("UPDATE subscriber SET cursor = NULL WHERE key = 'recipe-user-fts-query'")
+                .execute(connection)
+                .await?;
+
+            Ok(())
+        }
+
+        async fn down(
+            &self,
+            _connection: &mut sqlx::SqliteConnection,
+        ) -> Result<(), sqlx_migrator::Error> {
+            Ok(())
+        }
+    }
+}
+
 pub(crate) mod m0007 {
     pub struct AddBlurPlaceholder;
 


### PR DESCRIPTION
## Problem

`handle_ingredients_changed` in `crates/core/src/recipe/query/user_fts.rs` wrote the joined ingredient list into the `recipe_user_fts` **`name`** column instead of **`ingredients`**. For any recipe that emitted an `IngredientsChanged` event this:

- clobbered the recipe **name** in the FTS index with the ingredient list
- never refreshed the **ingredients** column, leaving it stale

Search by name (and by updated ingredients) was broken for those recipes.

## Fix

- Point the projection handler at `RecipeUserFts::Ingredients`.
- Add migration `m0010` to rebuild the corrupted index: truncate `recipe_user_fts` (built with sea-query, matching `user_login::m0005`) and reset the `recipe-user-fts-query` subscription cursor to `NULL` so the fixed handlers replay every event. The `subscriber` reset stays raw SQL — evento owns that table and it has no `Iden` (per the `recipe_owner.rs` convention).

## Verification

- `cargo fmt`, `cargo clippy -p imkitchen-db -p imkitchen-core` — clean.
- `cargo build -p imkitchen-db -p imkitchen-core` — compiles.
- On startup against an existing DB, m0010 truncates the FTS table and the reset subscription replays; search by recipe name and by ingredient both return the recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)