### PR TITLE
fix(search): sanitize user input for FTS5 MATCH queries

### DIFF
--- a/crates/core/src/contact/query/admin.rs
+++ b/crates/core/src/contact/query/admin.rs
@@ -85,13 +85,20 @@ impl<E: Executor> crate::contact::Module<E> {
             statement.and_where(Expr::col(ContactAdmin::Status).eq(status.to_string()));
         }
 
-        if let Some(search) = input.search {
+        if let Some(match_query) = input
+            .search
+            .as_deref()
+            .and_then(imkitchen_db::fts::to_match_query)
+        {
             statement.and_where(
                 Expr::col(ContactAdmin::Id).in_subquery(
                     Query::select()
                         .column(ContactAdminFts::Id)
                         .from(ContactAdminFts::Table)
-                        .and_where(Expr::cust(format!("contact_admin_fts MATCH '{search}*'")))
+                        .and_where(Expr::cust_with_values(
+                            "contact_admin_fts MATCH ?",
+                            [match_query],
+                        ))
                         .order_by(ContactAdminFts::Rank, sea_query::Order::Asc)
                         .limit(20)
                         .take(),

--- a/crates/core/src/recipe/query/user.rs
+++ b/crates/core/src/recipe/query/user.rs
@@ -159,8 +159,11 @@ impl<E: Executor> crate::recipe::Module<E> {
         // When a search term is present we join the FTS table (rather than an
         // `IN (subquery)` filter) so its `rank` is available for `ORDER BY`
         // below — an `IN` clause would discard the relevance ordering.
-        let search = query.search.filter(|s| !s.is_empty());
-        if let Some(ref search) = search {
+        let search = query
+            .search
+            .as_deref()
+            .and_then(imkitchen_db::fts::to_match_query);
+        if let Some(ref match_query) = search {
             statement
                 .join(
                     sea_query::JoinType::InnerJoin,
@@ -170,7 +173,7 @@ impl<E: Executor> crate::recipe::Module<E> {
                 )
                 .and_where(Expr::cust_with_values(
                     "recipe_user_fts MATCH ?",
-                    [format!("{search}*")],
+                    [match_query.clone()],
                 ));
         }
 

--- a/crates/db/src/fts.rs
+++ b/crates/db/src/fts.rs
@@ -1,0 +1,85 @@
+/// Convert a raw user search string into a safe FTS5 MATCH expression.
+///
+/// Each whitespace-separated token is wrapped as an FTS5 quoted string (embedded
+/// `"` doubled) with a trailing `*` for prefix matching, joined by spaces
+/// (implicit AND). Wrapping every token in quotes means FTS5 operators and
+/// special characters (`"`, `*`, `(`, `)`, `:`, `-`, `AND`, `OR`, `NOT`, `NEAR`)
+/// in user input are treated as literal text rather than query syntax, so no
+/// input can cause a MATCH syntax error.
+///
+/// Returns `None` when the input has no tokens, so callers can skip the filter
+/// instead of emitting an empty MATCH (which is itself an FTS5 syntax error).
+///
+/// Note: the returned string must still be bound as a parameter (e.g. via
+/// `sea_query`'s `cust_with_values` / a `?` placeholder), never interpolated
+/// into SQL — this function makes the value safe for FTS5, not for SQL.
+pub fn to_match_query(search: &str) -> Option<String> {
+    let query = search
+        .split_whitespace()
+        .map(|token| format!("\"{}\"*", token.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    (!query.is_empty()).then_some(query)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_match_query;
+
+    #[test]
+    fn plain_word() {
+        assert_eq!(to_match_query("chicken").as_deref(), Some("\"chicken\"*"));
+    }
+
+    #[test]
+    fn multi_word_is_prefix_and() {
+        assert_eq!(
+            to_match_query("chicken soup").as_deref(),
+            Some("\"chicken\"* \"soup\"*"),
+        );
+    }
+
+    #[test]
+    fn collapses_extra_whitespace() {
+        assert_eq!(
+            to_match_query("  chicken\t soup \n").as_deref(),
+            Some("\"chicken\"* \"soup\"*"),
+        );
+    }
+
+    #[test]
+    fn escapes_embedded_double_quote() {
+        // `a"b` -> quoted string with the `"` doubled, then prefix `*`.
+        assert_eq!(to_match_query("a\"b").as_deref(), Some("\"a\"\"b\"*"));
+    }
+
+    #[test]
+    fn fts_operators_are_literal() {
+        // Operators/keywords must not be interpreted; each token is quoted.
+        assert_eq!(
+            to_match_query("a AND b").as_deref(),
+            Some("\"a\"* \"AND\"* \"b\"*"),
+        );
+        assert_eq!(to_match_query("-tomato").as_deref(), Some("\"-tomato\"*"));
+        assert_eq!(to_match_query("foo:bar").as_deref(), Some("\"foo:bar\"*"));
+        assert_eq!(to_match_query("(").as_deref(), Some("\"(\"*"));
+        assert_eq!(to_match_query("soup*").as_deref(), Some("\"soup*\"*"));
+    }
+
+    #[test]
+    fn sql_injection_attempt_is_literal() {
+        // Even if this were interpolated it is now inert; bound as a param it is
+        // doubly safe. Verify it stays a single quoted token per word.
+        assert_eq!(
+            to_match_query("x' OR '1'='1").as_deref(),
+            Some("\"x'\"* \"OR\"* \"'1'='1\"*"),
+        );
+    }
+
+    #[test]
+    fn empty_and_whitespace_are_none() {
+        assert_eq!(to_match_query(""), None);
+        assert_eq!(to_match_query("   \t\n "), None);
+    }
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod m0010;
 
 pub mod contact_admin;
 pub mod contact_global_stat;
+pub mod fts;
 pub mod mealplan_recipe;
 pub mod mealplan_slot;
 pub mod notification_recipient;

--- a/crates/identity/src/query/admin.rs
+++ b/crates/identity/src/query/admin.rs
@@ -161,13 +161,20 @@ impl<E: Executor> crate::Module<E> {
             statement.and_where(Expr::col(UserAdmin::State).eq(status.to_string()));
         }
 
-        if let Some(search) = input.search {
+        if let Some(match_query) = input
+            .search
+            .as_deref()
+            .and_then(imkitchen_db::fts::to_match_query)
+        {
             statement.and_where(
                 Expr::col(UserAdmin::Id).in_subquery(
                     Query::select()
                         .column(UserAdminFts::Id)
                         .from(UserAdminFts::Table)
-                        .and_where(Expr::cust(format!("user_admin_fts MATCH '{search}*'")))
+                        .and_where(Expr::cust_with_values(
+                            "user_admin_fts MATCH ?",
+                            [match_query],
+                        ))
                         .order_by(UserAdminFts::Rank, sea_query::Order::Asc)
                         .limit(20)
                         .take(),


### PR DESCRIPTION
## Context

User search terms flowed into SQLite FTS5 `MATCH` clauses without sanitization, causing two distinct problems:

1. **SQL injection (real bug)** — the contact-admin and user-admin searches built the clause with raw string interpolation:
   ```rust
   .and_where(Expr::cust(format!("contact_admin_fts MATCH '{search}*'")))
   ```
   Input like `x' OR '1'='1` breaks out of the single-quoted SQL literal.

2. **FTS5 query-syntax errors (all three sites, incl. recipe)** — even when bound as a `?` parameter, the raw string is parsed as an FTS5 *MATCH expression*. Characters/keywords like `"`, `*`, `(`, `:`, `-`, `AND`, `OR`, `NEAR` change behavior or throw a syntax error (a lone `"` → "unterminated string" → 500).

## Changes

- **New shared sanitizer** `imkitchen_db::fts::to_match_query` (`crates/db/src/fts.rs`): wraps each whitespace-separated token as a quoted FTS5 string (embedded `"` doubled) with a trailing `*` for prefix matching, joined by spaces (implicit AND). Operators become inert literals; empty/whitespace input returns `None` so callers skip the filter (an empty `MATCH` is itself an FTS5 error). Covered by 7 unit tests.
- **Recipe search** (`crates/core/src/recipe/query/user.rs`) — sanitizes before binding to the `?` parameter.
- **Contact admin** (`crates/core/src/contact/query/admin.rs`) & **user admin** (`crates/identity/src/query/admin.rs`) — moved off raw interpolation onto bound `cust_with_values`, closing the injection hole *and* the FTS-grammar issue.

## Behavior notes

- Multi-word input is now **per-token prefix + AND** (`chicken soup` → `"chicken"* "soup"*`), a slight change from "only the last word was a prefix".
- An empty/whitespace admin search previously produced `MATCH '*'`; it now cleanly skips the filter and returns the full list.

## Verification

- `cargo test -p imkitchen-db fts` — 7/7 pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo build -p imkitchen-core -p imkitchen-identity` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)